### PR TITLE
[add]lint用のCI設定ファイルを追加

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+# DefaultSetting
+# ref: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Google
+IndentWidth: 4
+Language: Cpp
+Standard: Auto
+UseCRLF: false
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    paths-ignore: "build*/**"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: shenxianpeng/cpp-linter-action@master
+      id: linter
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        style: file
+    - name: failed on occurred error
+      if: steps.linter.outputs.checks-failed > 0
+      run: |
+        echo "Some files failed the linting checks!"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build-qt_src*Debug/*
 .stash
 test/*
 
+!.github/
+!.github/workflows/
 !.clang-format
 !.vscode
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build-qt_src*Debug/*
 .stash
 test/*
 
+!.clang-format
 !.vscode
 
 !test/*.cpp


### PR DESCRIPTION
## 概要
現状のコードはインデント幅やコーディングスタイルがバラバラであり、可読性が高いとは言えない。
そこで、GitHub Actions を用いて CI を導入して半自動的にこの問題を解消するために、設定ファイル群をこの PR で追加する。

## 備考
- [利用したAction - shenxianpeng/cpp-linter-action](https://github.com/shenxianpeng/cpp-linter-action)
- [.clang-formatの編集に使えるWebツール](https://pystyle.info/apps/clang-format-editor/)
- [Clang-Formatの設定オプションについて](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)