### PR TITLE
[refactor]clang-format に応じて既存のコードを format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+# DefaultSetting
+# ref: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Google
+IndentWidth: 4
+Language: Cpp
+Standard: Auto
+UseCRLF: false
+

--- a/include/aes_c.hpp
+++ b/include/aes_c.hpp
@@ -1,63 +1,64 @@
 #ifndef ___AES_HPP
 #define ___AES_HPP
 
-#include "openssl/aes.h"
-#include "openssl/evp.h"
-#include <openssl/rand.h>
 #include <memory.h>
+#include <openssl/rand.h>
 #include <stdio.h>
+
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "dynamic_mem_c.hpp"
 #include "macro.hpp"
+#include "openssl/aes.h"
+#include "openssl/evp.h"
 
-class aes_c
-{
-private:
-	std::vector<u_int8_t> key;
-	std::vector<u_int8_t> iv;
-	aes_c(const aes_c &);
+class aes_c {
+   private:
+    std::vector<u_int8_t> key;
+    std::vector<u_int8_t> iv;
+    aes_c(const aes_c &);
 
-public:
-	aes_c();
-	~aes_c();
+   public:
+    aes_c();
+    ~aes_c();
 
-	enum class AES_bit_e
-	{
-		aes_128,
-		aes_256,
-	};
+    enum class AES_bit_e {
+        aes_128,
+        aes_256,
+    };
 
-	void set_key(const std::string hex);
-	std::string get_key() const;
-	void create_key(int bit);
-	void remove_key();
+    void set_key(const std::string hex);
+    std::string get_key() const;
+    void create_key(int bit);
+    void remove_key();
 
-	void set_iv(const std::string hex);
-	std::string get_iv() const;
-	void create_iv(const int bit);
-	void remove_iv();
+    void set_iv(const std::string hex);
+    std::string get_iv() const;
+    void create_iv(const int bit);
+    void remove_iv();
 
-	bool set_iv_key(const dynamic_mem_c &iv, const dynamic_mem_c &key);
+    bool set_iv_key(const dynamic_mem_c &iv, const dynamic_mem_c &key);
 
-	void reset();
+    void reset();
 
-	void encrypt(std::string &out, const std::string in, const AES_bit_e bit);
-	void encrypt(dynamic_mem_c &out, const dynamic_mem_c &in, const AES_bit_e bit);
+    void encrypt(std::string &out, const std::string in, const AES_bit_e bit);
+    void encrypt(dynamic_mem_c &out, const dynamic_mem_c &in,
+                 const AES_bit_e bit);
 
-	void decrypt(std::string &out, const std::string in, const AES_bit_e bit);
-	void decrypt(dynamic_mem_c &out, const dynamic_mem_c &in, const AES_bit_e bit);
+    void decrypt(std::string &out, const std::string in, const AES_bit_e bit);
+    void decrypt(dynamic_mem_c &out, const dynamic_mem_c &in,
+                 const AES_bit_e bit);
 
-	void print_0x(const std::string header, const std::string &buf) const;
-	std::string ui2hex(const std::vector<uint8_t> src) const;
-	std::string str2hex(const std::string src) const;
-	std::string hex2str(const std::string src) const;
+    void print_0x(const std::string header, const std::string &buf) const;
+    std::string ui2hex(const std::vector<uint8_t> src) const;
+    std::string str2hex(const std::string src) const;
+    std::string hex2str(const std::string src) const;
 };
 
 #endif

--- a/include/device_c.hpp
+++ b/include/device_c.hpp
@@ -1,39 +1,37 @@
 #ifndef ___DEVICE_HPP
 #define ___DEVICE_HPP
 
-#include "error.hpp"
-#include "macro.hpp"
-
-#include "string"
-#include "fstream"
-#include "iostream"
-#include "sstream"
-#include "vector"
-#include "cstdio"
-#include "algorithm"
-#include "memory"
-
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <unistd.h>
 
-class device_c
-{
-private:
-	std::string usb_id_;
-	std::string usb_serial_;
+#include "algorithm"
+#include "cstdio"
+#include "error.hpp"
+#include "fstream"
+#include "iostream"
+#include "macro.hpp"
+#include "memory"
+#include "sstream"
+#include "string"
+#include "vector"
 
-public:
-	device_c();
-	~device_c();
+class device_c {
+   private:
+    std::string usb_id_;
+    std::string usb_serial_;
 
-	std::vector<std::string> get_usbList() const;
-	bool set_usbID(const std::string);
-	std::string get_usbID() const;
+   public:
+    device_c();
+    ~device_c();
 
-	std::string get_usbSerial() const;
-	uint32_t get_usb_cnt() const;
+    std::vector<std::string> get_usbList() const;
+    bool set_usbID(const std::string);
+    std::string get_usbID() const;
+
+    std::string get_usbSerial() const;
+    uint32_t get_usb_cnt() const;
 };
 
 #endif

--- a/include/dynamic_mem_c.hpp
+++ b/include/dynamic_mem_c.hpp
@@ -3,24 +3,23 @@
 
 #include <memory.h>
 #include <stdio.h>
+
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 #include "macro.hpp"
 
-class dynamic_mem_c
-{
-private:
+class dynamic_mem_c {
+   private:
     size_t size_;
     int usage_;
 
-public:
+   public:
     dynamic_mem_c();
     dynamic_mem_c(const uint size);
     ~dynamic_mem_c();

--- a/include/error.hpp
+++ b/include/error.hpp
@@ -1,17 +1,19 @@
 #ifndef ___ERROR_HPP
 #define ___ERROR_HPP
 
-#include "macro.hpp"
-
 #include <stdio.h>
-#include <cstdio>
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <sstream>
 #include <time.h>
 
-void push_error_log(const char *comment, const char *file, const char *func, const int line);
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "macro.hpp"
+
+void push_error_log(const char *comment, const char *file, const char *func,
+                    const int line);
 
 #endif

--- a/include/file_enc.hpp
+++ b/include/file_enc.hpp
@@ -1,109 +1,103 @@
 #ifndef ___FILE_ENC_HPP
 #define ___FILE_ENC_HPP
 
-#include "string"
-#include "fstream"
-#include "iostream"
-#include "cstdio"
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <unistd.h>
 
-#include "openssl/rand.h"
-
 #include "aes_c.hpp"
-#include "sha_c.hpp"
+#include "cstdio"
+#include "fstream"
+#include "iostream"
 #include "macro.hpp"
+#include "openssl/rand.h"
+#include "sha_c.hpp"
+#include "string"
 
-class file_enc_c
-{
-private:
-	file_enc_c(const file_enc_c &);
+class file_enc_c {
+   private:
+    file_enc_c(const file_enc_c &);
 
-	std::string file_path_;
-	std::string file_buff_;
-	std::string enc_buf_;
-	std::string password_;
-	std::string safe_pass_;
-	bool isExit_;
-	bool isFile_;
-	bool isDir_;
-	bool isEncrypt_;
-	bool isNoEncrypt_;
+    std::string file_path_;
+    std::string file_buff_;
+    std::string enc_buf_;
+    std::string password_;
+    std::string safe_pass_;
+    bool isExit_;
+    bool isFile_;
+    bool isDir_;
+    bool isEncrypt_;
+    bool isNoEncrypt_;
 
-	size_t getFileSize(FILE *fp) const;
-	void file_delete(std::string const file_path) const;
+    size_t getFileSize(FILE *fp) const;
+    void file_delete(std::string const file_path) const;
 
-public:
-	file_enc_c();
-	~file_enc_c();
+   public:
+    file_enc_c();
+    ~file_enc_c();
 
-	enum class CRYPT_MODE
-	{
-		DECRYPT,
-		ENCRYPT
-	};
+    enum class CRYPT_MODE { DECRYPT, ENCRYPT };
 
-	bool set_file_path(std::string filepath);
-	bool set_password(std::string pass);
-	bool file_enc();
-	bool file_dec();
-	bool crypt_process(aes_c &aes, file_enc_c::CRYPT_MODE const mode) const;
-	bool calc_file_hash(const std::string file_name, dynamic_mem_c &out) const;
-	void extemsion_set(const file_enc_c::CRYPT_MODE mode);
-	std::string get_file_pass() const;
+    bool set_file_path(std::string filepath);
+    bool set_password(std::string pass);
+    bool file_enc();
+    bool file_dec();
+    bool crypt_process(aes_c &aes, file_enc_c::CRYPT_MODE const mode) const;
+    bool calc_file_hash(const std::string file_name, dynamic_mem_c &out) const;
+    void extemsion_set(const file_enc_c::CRYPT_MODE mode);
+    std::string get_file_pass() const;
 
-	bool is_file_exit() const;
-	bool is_file() const;
-	bool is_dir() const;
-	bool is_enc() const;
-	bool is_no_enc() const;
+    bool is_file_exit() const;
+    bool is_file() const;
+    bool is_dir() const;
+    bool is_enc() const;
+    bool is_no_enc() const;
 };
 
-class key_list_c
-{
-private:
-	key_list_c(const key_list_c &);
-	const std::string key_file_name_ = KEY_FILE_NAME;
+class key_list_c {
+   private:
+    key_list_c(const key_list_c &);
+    const std::string key_file_name_ = KEY_FILE_NAME;
 
-	// 該当ハッシュ値のファイルをデータベースから削除し、以降のファイルを埋める
-	// 重複は両方削除される
-	bool plug(const dynamic_mem_c &hash);
+    // 該当ハッシュ値のファイルをデータベースから削除し、以降のファイルを埋める
+    // 重複は両方削除される
+    bool plug(const dynamic_mem_c &hash);
 
-public:
-	key_list_c();
-	~key_list_c();
+   public:
+    key_list_c();
+    ~key_list_c();
 
-	std::string get_file_name() const;
+    std::string get_file_name() const;
 
-	// ハッシュ値でファイルを検索し、iv, keyを取得
-	bool pop_file(dynamic_mem_c const &hash, dynamic_mem_c &iv, dynamic_mem_c &key);
-	// データベースにファイルを登録
-	bool add_file(dynamic_mem_c const &hash, dynamic_mem_c const &iv, dynamic_mem_c const &key) const;
-	// 鍵ファイルを暗号化 AES-256bit
-	bool encrypt(dynamic_mem_c const &key) const;
-	// 鍵ファイルを復号 AES-256bit
-	bool decrypt(dynamic_mem_c const &key) const;
-	// 鍵リストの共通鍵が正しいか確認
-	bool key_check(dynamic_mem_c const &key) const;
-	// 鍵リストの共通鍵のハッシュ値をファイルに上書き
-	bool key_list_pkey_update(dynamic_mem_c const &key) const;
+    // ハッシュ値でファイルを検索し、iv, keyを取得
+    bool pop_file(dynamic_mem_c const &hash, dynamic_mem_c &iv,
+                  dynamic_mem_c &key);
+    // データベースにファイルを登録
+    bool add_file(dynamic_mem_c const &hash, dynamic_mem_c const &iv,
+                  dynamic_mem_c const &key) const;
+    // 鍵ファイルを暗号化 AES-256bit
+    bool encrypt(dynamic_mem_c const &key) const;
+    // 鍵ファイルを復号 AES-256bit
+    bool decrypt(dynamic_mem_c const &key) const;
+    // 鍵リストの共通鍵が正しいか確認
+    bool key_check(dynamic_mem_c const &key) const;
+    // 鍵リストの共通鍵のハッシュ値をファイルに上書き
+    bool key_list_pkey_update(dynamic_mem_c const &key) const;
 };
 
-class file_ptr_c
-{
-private:
-	file_ptr_c(const file_ptr_c &);
+class file_ptr_c {
+   private:
+    file_ptr_c(const file_ptr_c &);
 
-public:
-	file_ptr_c(const std::string filepath, const std::string option);
-	file_ptr_c();
-	~file_ptr_c();
-	bool open(const std::string filepath, const std::string option);
-	bool reopen(const std::string filepath, const std::string option);
-	void close();
-	FILE *fp_;
+   public:
+    file_ptr_c(const std::string filepath, const std::string option);
+    file_ptr_c();
+    ~file_ptr_c();
+    bool open(const std::string filepath, const std::string option);
+    bool reopen(const std::string filepath, const std::string option);
+    void close();
+    FILE *fp_;
 };
 
 #endif

--- a/include/key_gen.hpp
+++ b/include/key_gen.hpp
@@ -1,55 +1,53 @@
 #ifndef ___KEY_GEN_HPP
 #define ___KEY_GEN_HPP
 
-#include "dynamic_mem_c.hpp"
-#include "sha_c.hpp"
-#include "macro.hpp"
-#include "file_enc.hpp"
-#include "error.hpp"
-
-#include "string"
-#include "fstream"
-#include "iostream"
-#include "cstdio"
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
 #include <unistd.h>
 
+#include "cstdio"
+#include "dynamic_mem_c.hpp"
+#include "error.hpp"
+#include "file_enc.hpp"
+#include "fstream"
+#include "iostream"
+#include "macro.hpp"
 #include "openssl/rand.h"
+#include "sha_c.hpp"
+#include "string"
 
-class key_gen_c
-{
-private:
-	key_gen_c(const key_gen_c &);
+class key_gen_c {
+   private:
+    key_gen_c(const key_gen_c &);
 
-	dynamic_mem_c key_;
-	std::string pass_;
-	std::string usbID_;
-	std::string usbSerial_;
+    dynamic_mem_c key_;
+    std::string pass_;
+    std::string usbID_;
+    std::string usbSerial_;
 
-	std::string get_pass() const;
-	std::string get_usbSerial() const;
+    std::string get_pass() const;
+    std::string get_usbSerial() const;
 
-protected:
-public:
-	key_gen_c();
-	~key_gen_c();
+   protected:
+   public:
+    key_gen_c();
+    ~key_gen_c();
 
-	bool new_key_gen();
-	bool key_gen();
+    bool new_key_gen();
+    bool key_gen();
 
-	bool set_pass(std::string const pass);
+    bool set_pass(std::string const pass);
 
-	bool set_usbID(std::string const id);
-	std::string get_usbID() const;
-	bool set_UsbSerial();
+    bool set_usbID(std::string const id);
+    std::string get_usbID() const;
+    bool set_UsbSerial();
 
-	bool get_nonce(dynamic_mem_c &to) const;
-	bool set_nonce() const;
+    bool get_nonce(dynamic_mem_c &to) const;
+    bool set_nonce() const;
 
-	dynamic_mem_c get_key() const;
-	bool canKeyGen() const;
+    dynamic_mem_c get_key() const;
+    bool canKeyGen() const;
 };
 
 #endif

--- a/include/macro.hpp
+++ b/include/macro.hpp
@@ -4,16 +4,17 @@
 #include "error.hpp"
 
 // エラー用マクロ
-#define ERROR(comment)                                                                   \
-	printf("[ERROR]\n\t__%s__/__%s: %d\n\t%s\n", __FILE__, __func__, __LINE__, comment); \
-	push_error_log(comment, __FILE__, __func__, __LINE__)
+#define ERROR(comment)                                                         \
+    printf("[ERROR]\n\t__%s__/__%s: %d\n\t%s\n", __FILE__, __func__, __LINE__, \
+           comment);                                                           \
+    push_error_log(comment, __FILE__, __func__, __LINE__)
 
 #define ERROR_NO_COMMENT                                                  \
-	printf("[ERROR]\n\t__%s__/__%s: %d\n", __FILE__, __func__, __LINE__); \
-	push_error_log("", __FILE__, __func__, __LINE__)
+    printf("[ERROR]\n\t__%s__/__%s: %d\n", __FILE__, __func__, __LINE__); \
+    push_error_log("", __FILE__, __func__, __LINE__)
 
 #define PRINT_ERROR_LOG(comment) \
-	push_error_log(comment, __FILE__, __func__, __LINE__)
+    push_error_log(comment, __FILE__, __func__, __LINE__)
 
 // -----------------------------------------------------------------------
 // 定数

--- a/include/sha_c.hpp
+++ b/include/sha_c.hpp
@@ -1,33 +1,32 @@
 #ifndef ___SHA1_HPP
 #define ___SHA1_HPP
 
-#include "openssl/aes.h"
-#include "openssl/evp.h"
-#include "openssl/sha.h"
-#include <openssl/rand.h>
 #include <memory.h>
+#include <openssl/rand.h>
 #include <stdio.h>
+
 #include <cstdio>
 #include <cstdlib>
-#include <vector>
 #include <iostream>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "dynamic_mem_c.hpp"
 #include "macro.hpp"
+#include "openssl/aes.h"
+#include "openssl/evp.h"
+#include "openssl/sha.h"
 
-class SHA_c
-{
-private:
+class SHA_c {
+   private:
     SHA_c(const SHA_c &);
 
-public:
+   public:
     SHA_c();
     ~SHA_c();
-    enum class SHA2_bit
-    {
+    enum class SHA2_bit {
         SHA_224,
         SHA_256,
         SHA_384,
@@ -36,7 +35,8 @@ public:
 
     std::string sha1_cal(const std::string &src) const;
     std::string sha2_cal(const std::string &src, const SHA2_bit bit) const;
-    bool sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit bit) const;
+    bool sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out,
+                  const SHA2_bit bit) const;
 
     std::string str2hex(const std::string &src) const;
     std::string str2hex(const dynamic_mem_c &src) const;

--- a/qt_src/dialog_dec_pass.cpp
+++ b/qt_src/dialog_dec_pass.cpp
@@ -1,44 +1,39 @@
 #include "dialog_dec_pass.h"
+
 #include "ui_dialog_dec_pass.h"
 
-Dialog_dec_pass::Dialog_dec_pass(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::Dialog_dec_pass)
-{
+Dialog_dec_pass::Dialog_dec_pass(QWidget *parent)
+    : QDialog(parent), ui(new Ui::Dialog_dec_pass) {
     ui->setupUi(this);
 }
 
-Dialog_dec_pass::~Dialog_dec_pass()
-{
-    delete ui;
-}
+Dialog_dec_pass::~Dialog_dec_pass() { delete ui; }
 
 using namespace std;
 
 //ファイル復号
-void Dialog_dec_pass::on_buttonBox_accepted()
-{
+void Dialog_dec_pass::on_buttonBox_accepted() {
     QString pass = ui->lineEdit_dec_pass->text();
-    if(pass.size() == 0){
+    if (pass.size() == 0) {
         return;
     }
 
-//    ファイルパス渡し
+    //    ファイルパス渡し
     file_enc_c file_dec;
     file_dec.set_file_path(this->file_path_);
-    if(file_dec.is_file_exit() == false){
+    if (file_dec.is_file_exit() == false) {
         return;
     }
 
     //復号
     file_dec.set_password(ui->lineEdit_dec_pass->text().toStdString());
-    if(file_dec.file_dec() == false){
+    if (file_dec.file_dec() == false) {
         cerr << "復号に失敗しました" << endl;
     }
 
     this->close();
 }
 
-void Dialog_dec_pass::set_file_path(string file_path){
+void Dialog_dec_pass::set_file_path(string file_path) {
     this->file_path_ = file_path;
 }

--- a/qt_src/dialog_dec_pass.h
+++ b/qt_src/dialog_dec_pass.h
@@ -2,35 +2,33 @@
 #define DIALOG_DEC_PASS_H
 
 #include <QDialog>
-#include "iostream"
-#include "string"
 #include <chrono>
 
 #include "../include/file_enc.hpp"
+#include "iostream"
+#include "string"
 
 namespace Ui {
 class Dialog_dec_pass;
 }
 
-class Dialog_dec_pass : public QDialog
-{
+class Dialog_dec_pass : public QDialog {
     Q_OBJECT
 
-public:
+   public:
     explicit Dialog_dec_pass(QWidget *parent = 0);
     ~Dialog_dec_pass();
 
     void set_file_path(std::string file_pass);
 
-
-private slots:
+   private slots:
 
     void on_buttonBox_accepted();
 
-private:
+   private:
     Ui::Dialog_dec_pass *ui;
 
     std::string file_path_;
 };
 
-#endif // DIALOG_DEC_PASS_H
+#endif  // DIALOG_DEC_PASS_H

--- a/qt_src/dialog_password.cpp
+++ b/qt_src/dialog_password.cpp
@@ -1,14 +1,13 @@
 #include "dialog_password.h"
+
 #include "ui_dialog_password.h"
 
 using namespace std;
 
 bool IS_PASSWORD_CORRECT;
 
-Dialog_password::Dialog_password(QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::Dialog_password)
-{
+Dialog_password::Dialog_password(QWidget *parent)
+    : QDialog(parent), ui(new Ui::Dialog_password) {
     ui->setupUi(this);
 
     IS_PASSWORD_CORRECT = false;
@@ -16,34 +15,26 @@ Dialog_password::Dialog_password(QWidget *parent) :
     this->is_ok_ = false;
 }
 
-Dialog_password::~Dialog_password()
-{
-    delete ui;
-}
+Dialog_password::~Dialog_password() { delete ui; }
 
-bool Dialog_password::is_ok() const{
-    return this->is_ok_;
-}
+bool Dialog_password::is_ok() const { return this->is_ok_; }
 
-bool Dialog_password::is_calcel() const{
-    return this->is_canceled_;
-}
+bool Dialog_password::is_calcel() const { return this->is_canceled_; }
 
-void Dialog_password::set_file_path(string file_path){
+void Dialog_password::set_file_path(string file_path) {
     this->file_path_ = file_path;
 }
 
-
 //パスワード二重チェック
-void Dialog_password::on_lineEdit_password_check_textChanged(const QString &arg1)
-{
+void Dialog_password::on_lineEdit_password_check_textChanged(
+    const QString &arg1) {
     QString input_pass_ck = arg1;
     QString input_pass_origin = ui->lineEdit_password->text();
-    QString  out_put;
-    if(input_pass_origin == input_pass_ck){
+    QString out_put;
+    if (input_pass_origin == input_pass_ck) {
         out_put.push_back("OK");
         IS_PASSWORD_CORRECT = true;
-    }else{
+    } else {
         out_put.push_back(("NG"));
         IS_PASSWORD_CORRECT = false;
     }
@@ -51,28 +42,24 @@ void Dialog_password::on_lineEdit_password_check_textChanged(const QString &arg1
 }
 
 //暗号化を行う
-void Dialog_password::on_pushButton_OK_clicked()
-{
-    if(!IS_PASSWORD_CORRECT){
+void Dialog_password::on_pushButton_OK_clicked() {
+    if (!IS_PASSWORD_CORRECT) {
         return;
     }
 
     this->is_ok_ = true;
     file_enc_c file_enc;
     file_enc.set_file_path(this->file_path_);
-    if(file_enc.is_file_exit() == false){
+    if (file_enc.is_file_exit() == false) {
         return;
     }
 
     file_enc.set_password(ui->lineEdit_password->text().toStdString());
-    if(file_enc.file_enc() == false){
+    if (file_enc.file_enc() == false) {
         cerr << "暗号化に失敗しました" << endl;
     }
 
     this->close();
 }
 
-void Dialog_password::on_pushButton_Cancel_clicked()
-{
-    this->close();
-}
+void Dialog_password::on_pushButton_Cancel_clicked() { this->close(); }

--- a/qt_src/dialog_password.h
+++ b/qt_src/dialog_password.h
@@ -2,18 +2,18 @@
 #define DIALOG_PASSWORD_H
 
 #include <QDialog>
-#include "../include/file_enc.hpp"
 #include <chrono>
+
+#include "../include/file_enc.hpp"
 
 namespace Ui {
 class Dialog_password;
 }
 
-class Dialog_password : public QDialog
-{
+class Dialog_password : public QDialog {
     Q_OBJECT
 
-public:
+   public:
     explicit Dialog_password(QWidget *parent = 0);
     ~Dialog_password();
 
@@ -22,7 +22,7 @@ public:
 
     void set_file_path(std::string file_path);
 
-private slots:
+   private slots:
 
     void on_lineEdit_password_check_textChanged(const QString &arg1);
 
@@ -30,7 +30,7 @@ private slots:
 
     void on_pushButton_Cancel_clicked();
 
-private:
+   private:
     Ui::Dialog_password *ui;
 
     bool is_canceled_;
@@ -39,4 +39,4 @@ private:
     std::string file_path_;
 };
 
-#endif // DIALOG_PASSWORD_H
+#endif  // DIALOG_PASSWORD_H

--- a/qt_src/main.cpp
+++ b/qt_src/main.cpp
@@ -1,9 +1,9 @@
-#include "mainwindow.h"
 #include <QApplication>
-#include "QDialog"
 
-int main(int argc, char *argv[])
-{
+#include "QDialog"
+#include "mainwindow.h"
+
+int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
     MainWindow w;
     w.show();

--- a/qt_src/mainwindow.cpp
+++ b/qt_src/mainwindow.cpp
@@ -1,18 +1,13 @@
 #include "mainwindow.h"
+
 #include "ui_mainwindow.h"
 
-
-MainWindow::MainWindow(QWidget *parent) :
-    QMainWindow(parent),
-    ui(new Ui::MainWindow)
-{
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
 }
 
-MainWindow::~MainWindow()
-{
-    delete ui;
-}
+MainWindow::~MainWindow() { delete ui; }
 
 using namespace std;
 
@@ -20,30 +15,29 @@ namespace global {
 string selected_usbID;
 }
 
-void MainWindow::on_push_enc_clicked()
-{
+void MainWindow::on_push_enc_clicked() {
     static const string erase_string = "file://";
 
     string input_text = ui->lineEdit_file_path->text().toStdString();
 
-    if(input_text.empty()){
+    if (input_text.empty()) {
         return;
     }
 
-    if(input_text.find(erase_string.c_str()) != string::npos){
-        input_text.erase(input_text.find(erase_string.c_str()), erase_string.size());
+    if (input_text.find(erase_string.c_str()) != string::npos) {
+        input_text.erase(input_text.find(erase_string.c_str()),
+                         erase_string.size());
     }
 
     //暗号化
     file_enc_c file_enc;
     file_enc.set_file_path(input_text);
-    if(file_enc.is_file_exit() == false){
+    if (file_enc.is_file_exit() == false) {
         return;
     }
-    if(file_enc.file_enc() == false){
+    if (file_enc.file_enc() == false) {
         cerr << "暗号化に失敗しました" << endl;
     }
-
 
     //    get_password_wind = new Dialog_password(this);
     //    get_password_wind->set_file_path(input_text);
@@ -51,36 +45,35 @@ void MainWindow::on_push_enc_clicked()
 
     //    cout << "OK: " << get_password_wind->is_ok() << endl;
 
-
     cout << input_text << endl;
     ui->lineEdit_file_path->clear();
 }
 
-void MainWindow::on_push_dec_clicked()
-{
+void MainWindow::on_push_dec_clicked() {
     QString fail_path = ui->lineEdit_file_path->text();
-    if(fail_path.size() == 0){
+    if (fail_path.size() == 0) {
         return;
     }
 
     static const string erase_string = "file://";
     string input_text = ui->lineEdit_file_path->text().toStdString();
-    if(input_text.empty()){
+    if (input_text.empty()) {
         return;
     }
 
-    if(input_text.find(erase_string.c_str()) != string::npos){
-        input_text.erase(input_text.find(erase_string.c_str()), erase_string.size());
+    if (input_text.find(erase_string.c_str()) != string::npos) {
+        input_text.erase(input_text.find(erase_string.c_str()),
+                         erase_string.size());
     }
 
     //ファイルが存在するか確認
     file_enc_c file_dec;
     file_dec.set_file_path(input_text);
-    if(file_dec.is_file_exit() == false){
+    if (file_dec.is_file_exit() == false) {
         return;
     }
     //復号
-    if(file_dec.file_dec() == false){
+    if (file_dec.file_dec() == false) {
         cerr << "復号に失敗しました" << endl;
     }
     //    get_dec_pass_wind = new Dialog_dec_pass(this);
@@ -90,21 +83,19 @@ void MainWindow::on_push_dec_clicked()
     ui->lineEdit_file_path->clear();
 }
 
-void MainWindow::on_pushButton_clear_clicked()
-{
+void MainWindow::on_pushButton_clear_clicked() {
     ui->lineEdit_file_path->clear();
 }
 
-void MainWindow::on_pushButton_pass_register_clicked()
-{
+void MainWindow::on_pushButton_pass_register_clicked() {
     usb_select_wind = new usb_select(this);
     usb_select_wind->setModal(true);
     int ret = usb_select_wind->exec();
-    if(ret == QDialog::Accepted){
+    if (ret == QDialog::Accepted) {
         cout << "Accepted" << endl;
-        cout << "USB ID: "<< usb_select_wind->usbID_ << endl;
+        cout << "USB ID: " << usb_select_wind->usbID_ << endl;
 
-    }else if(ret == QDialog::Rejected){
+    } else if (ret == QDialog::Rejected) {
         cout << "Rejected" << endl;
     }
 }

--- a/qt_src/mainwindow.h
+++ b/qt_src/mainwindow.h
@@ -2,33 +2,30 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include "algorithm"
-#include "iostream"
 
 #include "../include/aes_c.hpp"
 #include "../include/file_enc.hpp"
-
-#include "dialog_password.h"
+#include "algorithm"
 #include "dialog_dec_pass.h"
+#include "dialog_password.h"
+#include "iostream"
 #include "usb_select.h"
-
 
 namespace Ui {
 class MainWindow;
 }
 
-class MainWindow : public QMainWindow
-{
+class MainWindow : public QMainWindow {
     Q_OBJECT
 
-public:
+   public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-private slots:
+   private slots:
     void on_push_enc_clicked();
 
-//    void on_pushButton_debug_clicked();
+    //    void on_pushButton_debug_clicked();
 
     void on_push_dec_clicked();
 
@@ -36,13 +33,13 @@ private slots:
 
     void on_pushButton_pass_register_clicked();
 
-//    void on_MainWindow_destroyed(QObject *arg1);
+    //    void on_MainWindow_destroyed(QObject *arg1);
 
-private:
+   private:
     Ui::MainWindow *ui;
     Dialog_password *get_password_wind;
     Dialog_dec_pass *get_dec_pass_wind;
     usb_select *usb_select_wind;
 };
 
-#endif // MAINWINDOW_H
+#endif  // MAINWINDOW_H

--- a/qt_src/pass_check.cpp
+++ b/qt_src/pass_check.cpp
@@ -1,14 +1,10 @@
 #include "pass_check.h"
+
 #include "ui_pass_check.h"
 
-pass_check::pass_check(QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::pass_check)
-{
+pass_check::pass_check(QWidget *parent)
+    : QWidget(parent), ui(new Ui::pass_check) {
     ui->setupUi(this);
 }
 
-pass_check::~pass_check()
-{
-    delete ui;
-}
+pass_check::~pass_check() { delete ui; }

--- a/qt_src/pass_check.h
+++ b/qt_src/pass_check.h
@@ -7,16 +7,15 @@ namespace Ui {
 class pass_check;
 }
 
-class pass_check : public QWidget
-{
+class pass_check : public QWidget {
     Q_OBJECT
 
-public:
+   public:
     explicit pass_check(QWidget *parent = 0);
     ~pass_check();
 
-private:
+   private:
     Ui::pass_check *ui;
 };
 
-#endif // PASS_CHECK_H
+#endif  // PASS_CHECK_H

--- a/qt_src/usb_select.cpp
+++ b/qt_src/usb_select.cpp
@@ -1,53 +1,46 @@
 #include "usb_select.h"
+
 #include "ui_usb_select.h"
 
-usb_select::usb_select(QWidget *parent) : QDialog(parent),
-    ui(new Ui::usb_select)
-{
+usb_select::usb_select(QWidget *parent)
+    : QDialog(parent), ui(new Ui::usb_select) {
     ui->setupUi(this);
 
     //起動時処理
     this->update();
 }
 
-usb_select::~usb_select(){
-
-}
-
+usb_select::~usb_select() {}
 
 using namespace std;
 
-//namespace global {
-//int usbID;
+// namespace global {
+// int usbID;
 //}
 
-
-bool usb_select::update()
-{
+bool usb_select::update() {
     device_c usb;
     vector<string> usb_list;
     usb_list = usb.get_usbList();
 
     //    USBリストを表示
-    for(string temp : usb_list){
+    for (string temp : usb_list) {
         new QListWidgetItem(tr(temp.c_str()), ui->listWidget_select);
     }
     return true;
 }
 
-//USB IDを抽出
-void usb_select::on_listWidget_select_itemClicked(QListWidgetItem *item)
-{
+// USB IDを抽出
+void usb_select::on_listWidget_select_itemClicked(QListWidgetItem *item) {
     string selected_usb{item->text().toStdString()};
-    this->usbID_ =  selected_usb.substr(3,9);
+    this->usbID_ = selected_usb.substr(3, 9);
     ui->label_selected_usbID->setText(QString::fromStdString(this->usbID_));
 }
 
-void usb_select::on_pushButton_ok_clicked()
-{
-    if(this->usbID_.empty()){
+void usb_select::on_pushButton_ok_clicked() {
+    if (this->usbID_.empty()) {
         return;
     }
-//    this->set_usbID(global::usbID)
+    //    this->set_usbID(global::usbID)
     this->done(1);
 }

--- a/qt_src/usb_select.h
+++ b/qt_src/usb_select.h
@@ -1,41 +1,37 @@
 #ifndef USB_SELECT_H
 #define USB_SELECT_H
 
-#include <QWidget>
+#include <unistd.h>
+
 #include <QDialog>
 #include <QListWidgetItem>
-
-#include <unistd.h>
-#include <vector>
+#include <QWidget>
 #include <string>
-
+#include <vector>
 
 #include "../include/device_c.hpp"
 
-namespace Ui
-{
-    class usb_select;
+namespace Ui {
+class usb_select;
 }
 
-class usb_select : public QDialog, public device_c
-{
+class usb_select : public QDialog, public device_c {
     Q_OBJECT
 
-public:
+   public:
     explicit usb_select(QWidget *parent = 0);
     ~usb_select();
 
     bool update();
     std::string usbID_;
 
-
-private slots:
+   private slots:
     void on_listWidget_select_itemClicked(QListWidgetItem *item);
 
     void on_pushButton_ok_clicked();
 
-private:
+   private:
     Ui::usb_select *ui;
 };
 
-#endif // USB_SELECT_H
+#endif  // USB_SELECT_H

--- a/src/RSA_c.cpp
+++ b/src/RSA_c.cpp
@@ -1,11 +1,12 @@
 #include "../include/RSA_c.hpp"
+
 #include "../include/dynamic_mem_c.hpp"
 
-#define ERROR(comment) \
-    printf("[ERROR]\n\t%s_%s: %d\n\t%s\n", __FILE__, __func__, __LINE__, comment)
+#define ERROR(comment)                                                   \
+    printf("[ERROR]\n\t%s_%s: %d\n\t%s\n", __FILE__, __func__, __LINE__, \
+           comment)
 
-RSA_c::RSA_c()
-{
+RSA_c::RSA_c() {
     this->key_size = 0;
     this->pub_key = nullptr;
     this->priv_key = nullptr;
@@ -14,20 +15,16 @@ RSA_c::RSA_c()
     this->PRIV_FILE_NAME = "RSA_private_key";
 }
 
-RSA_c::~RSA_c()
-{
-    if (this->priv_key)
-    {
+RSA_c::~RSA_c() {
+    if (this->priv_key) {
         OPENSSL_free(this->priv_key);
         this->priv_key = nullptr;
     }
-    if (this->pub_key)
-    {
+    if (this->pub_key) {
         OPENSSL_free(this->pub_key);
         this->pub_key = nullptr;
     }
-    if (this->key_pair)
-    {
+    if (this->key_pair) {
         OPENSSL_free(this->key_pair);
         this->key_pair = nullptr;
     }
@@ -36,42 +33,53 @@ RSA_c::~RSA_c()
 
 using namespace std;
 
-string RSA_c::decode_base64(string strData) const
-{
+string RSA_c::decode_base64(string strData) const {
     /*
         変換テーブル
     */
     const static unsigned char baTable[256] = {
-        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff,
+        0xff, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f,
+        0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+        0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
+        0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24,
+        0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+        0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff};
 
     string strRet;
     string::iterator ite = strData.begin();
     string::iterator iteEnd = strData.end();
 
-    while (ite != iteEnd)
-    {
-
+    while (ite != iteEnd) {
         unsigned long dwValue = 0;
         int nBitCount = 0;
 
         // 4バイト単位で処理する
         int nCount = 4;
-        while (nCount--)
-        {
-
+        while (nCount--) {
             // 1バイト取得
             dwValue <<= 6;
-            if (ite != iteEnd)
-            {
+            if (ite != iteEnd) {
                 unsigned char bChar = baTable[*ite++];
-                if (64 > bChar)
-                {
+                if (64 > bChar) {
                     dwValue |= bChar;
                     nBitCount += 6;
-                }
-                else if (0xfe == bChar)
-                {
-
+                } else if (0xfe == bChar) {
                     // 改行コードは完全に無視する
                     nCount++;
                     dwValue >>= 6;
@@ -86,8 +94,7 @@ string RSA_c::decode_base64(string strData) const
 
         // 最大３バイトの書き込み
         int nByte = nBitCount / 8;
-        if (0 < nByte)
-        {
+        if (0 < nByte) {
             strRet.append((char *)baWrite, nByte);
         }
     }
@@ -96,14 +103,14 @@ string RSA_c::decode_base64(string strData) const
     return (strRet);
 }
 
-string RSA_c::encrypt(const string &in) const
-{
+string RSA_c::encrypt(const string &in) const {
     dynamic_mem_c buf;
     buf.d_new(RSA_size(this->pub_key));
 
-    int out_size = RSA_public_encrypt(in.size(), (unsigned char *)in.c_str(), buf.mem, this->pub_key, RSA_PKCS1_OAEP_PADDING);
-    if (out_size <= 0)
-    {
+    int out_size =
+        RSA_public_encrypt(in.size(), (unsigned char *)in.c_str(), buf.mem,
+                           this->pub_key, RSA_PKCS1_OAEP_PADDING);
+    if (out_size <= 0) {
         int error = ERR_get_error();
         string str_error;
         str_error = ERR_reason_error_string(error);
@@ -118,13 +125,13 @@ string RSA_c::encrypt(const string &in) const
     return result;
 }
 
-string RSA_c::decrypt(const string &in) const
-{
+string RSA_c::decrypt(const string &in) const {
     dynamic_mem_c buf;
     buf.d_new(this->key_size);
-    int out_size = RSA_private_decrypt(in.length(), (unsigned char *)in.c_str(), buf.mem, this->priv_key, RSA_PKCS1_OAEP_PADDING);
-    if (out_size <= 0)
-    {
+    int out_size =
+        RSA_private_decrypt(in.length(), (unsigned char *)in.c_str(), buf.mem,
+                            this->priv_key, RSA_PKCS1_OAEP_PADDING);
+    if (out_size <= 0) {
         int error = ERR_get_error();
         string str_error;
         str_error = ERR_reason_error_string(error);
@@ -139,8 +146,7 @@ string RSA_c::decrypt(const string &in) const
     return result;
 }
 
-void RSA_c::create_key(const uint bit)
-{
+void RSA_c::create_key(const uint bit) {
     BIGNUM *bn = BN_new();
     BN_set_word(bn, RSA_F4);
 
@@ -155,20 +161,17 @@ void RSA_c::create_key(const uint bit)
     bn = nullptr;
 }
 
-string RSA_c::str2hex(const string &str) const
-{
+string RSA_c::str2hex(const string &str) const {
     stringstream buf;
     char p[10];
-    for (size_t i = 0; i < str.size(); i++)
-    {
+    for (size_t i = 0; i < str.size(); i++) {
         sprintf(p, "%02x", (unsigned char)str[i]);
         buf << p;
     }
     return buf.str();
 }
 
-string RSA_c::hex2bin(const string &hex) const
-{
+string RSA_c::hex2bin(const string &hex) const {
     char buf[3] = {0};
     unsigned char *bin = (unsigned char *)calloc(sizeof(char), hex.size());
     int binsize = hex.size();
@@ -178,8 +181,7 @@ string RSA_c::hex2bin(const string &hex) const
     result.erase(result.begin(), result.end());
     char *pch;
     memset((void *)bin, 0, hex.size());
-    for (size_t i = 0; i < hex.size(); i += 2)
-    {
+    for (size_t i = 0; i < hex.size(); i += 2) {
         buf[0] = hex[i];
         buf[1] = hex[i + 1];
         pch = buf;
@@ -192,16 +194,12 @@ string RSA_c::hex2bin(const string &hex) const
     return result;
 }
 
-string RSA_c::get_pub_key() const
-{
-}
+string RSA_c::get_pub_key() const {}
 
-void RSA_c::create_RSA_file(KEY_STATUS pem_type, std::string file_name)
-{
+void RSA_c::create_RSA_file(KEY_STATUS pem_type, std::string file_name) {
     FILE *fp = nullptr;
 
-    if (pem_type == KEY_STATUS::PUB_KEY)
-    {
+    if (pem_type == KEY_STATUS::PUB_KEY) {
         fp = fopen(file_name.c_str(), "w");
         PEM_write_RSAPublicKey(fp, this->key_pair);
         fclose(fp);
@@ -209,11 +207,10 @@ void RSA_c::create_RSA_file(KEY_STATUS pem_type, std::string file_name)
         fp = fopen(file_name.c_str(), "rb");
         PEM_read_RSAPublicKey(fp, &this->pub_key, NULL, NULL);
         fclose(fp);
-    }
-    else if (pem_type == KEY_STATUS::PRIV_KEY)
-    {
+    } else if (pem_type == KEY_STATUS::PRIV_KEY) {
         fp = fopen(file_name.c_str(), "w");
-        PEM_write_RSAPrivateKey(fp, this->key_pair, NULL, NULL, this->key_size, NULL, NULL);
+        PEM_write_RSAPrivateKey(fp, this->key_pair, NULL, NULL, this->key_size,
+                                NULL, NULL);
         fclose(fp);
 
         fp = fopen(file_name.c_str(), "rb");
@@ -224,37 +221,29 @@ void RSA_c::create_RSA_file(KEY_STATUS pem_type, std::string file_name)
     fp = nullptr;
 }
 
-string RSA_c::get_string_key(const KEY_STATUS &key) const
-{
+string RSA_c::get_string_key(const KEY_STATUS &key) const {
     string result;
-    if (key == KEY_STATUS::PUB_KEY)
-    {
+    if (key == KEY_STATUS::PUB_KEY) {
         ifstream iss(this->PUB_FILE_NAME);
-        if (!iss)
-        {
+        if (!iss) {
             ERROR("!iss");
             return nullptr;
         }
         string buf;
-        while (!iss.eof())
-        {
+        while (!iss.eof()) {
             std::getline(iss, buf);
             result += buf + "\n";
         }
         result.erase(0, strlen("-----BEGIN RSA PUBLIC KEY-----") + 1);
         result.erase(result.find("-----END RSA PUBLIC KEY-----") - 1);
-    }
-    else if (key == KEY_STATUS::PRIV_KEY)
-    {
+    } else if (key == KEY_STATUS::PRIV_KEY) {
         ifstream iss(this->PRIV_FILE_NAME);
-        if (!iss)
-        {
+        if (!iss) {
             ERROR("!iss");
             return nullptr;
         }
         string buf;
-        while (!iss.eof())
-        {
+        while (!iss.eof()) {
             std::getline(iss, buf);
             result += buf + "\n";
         }
@@ -267,8 +256,7 @@ string RSA_c::get_string_key(const KEY_STATUS &key) const
     return result;
 }
 
-void RSA_c::set_key()
-{
+void RSA_c::set_key() {
     FILE *fp;
     fp = fopen(this->PUB_FILE_NAME.c_str(), "rb");
     PEM_read_RSAPublicKey(fp, &this->pub_key, NULL, NULL);

--- a/src/aes_c.cpp
+++ b/src/aes_c.cpp
@@ -2,203 +2,171 @@
 
 using namespace std;
 
-aes_c::aes_c(/* args */)
-{
+aes_c::aes_c(/* args */) {}
+
+aes_c::~aes_c() {}
+
+void aes_c::set_iv(std::string hex) {
+    char buf[2] = {0};
+    char *bin = (char *)calloc(sizeof(char), hex.size());
+    int binsize = hex.size();
+    printf("binsize: %d\n", binsize);
+
+    this->remove_iv();
+    char *pch;
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        buf[0] = hex[i];
+        buf[1] = hex[i + 1];
+        pch = buf;
+        bin[i / 2] = (char)strtoul(pch, NULL, 16);
+        this->iv.push_back(bin[i / 2]);
+    }
+    free(bin);
+    bin = nullptr;
 }
 
-aes_c::~aes_c()
-{
+bool aes_c::set_iv_key(const dynamic_mem_c &iv, const dynamic_mem_c &key) {
+    if (iv.empty() || key.empty()) {
+        ERROR("");
+        return false;
+    }
+    if (iv.size() != key.size()) {
+        ERROR("");
+        return false;
+    }
+
+    for (size_t i = 0; i < iv.size(); i++) {
+        this->iv.push_back(iv.mem_[i]);
+        this->key.push_back(key.mem_[i]);
+    }
+    return true;
 }
 
-void aes_c::set_iv(std::string hex)
-{
-	char buf[2] = {0};
-	char *bin = (char *)calloc(sizeof(char), hex.size());
-	int binsize = hex.size();
-	printf("binsize: %d\n", binsize);
-
-	this->remove_iv();
-	char *pch;
-	for (size_t i = 0; i < hex.size(); i += 2)
-	{
-		buf[0] = hex[i];
-		buf[1] = hex[i + 1];
-		pch = buf;
-		bin[i / 2] = (char)strtoul(pch, NULL, 16);
-		this->iv.push_back(bin[i / 2]);
-	}
-	free(bin);
-	bin = nullptr;
+std::string aes_c::get_iv() const {
+    string iv;
+    stringstream ss;
+    char tch[10];
+    for (const auto &i : this->iv) {
+        sprintf(tch, "%02x", (int)i);
+        ss << tch;
+    }
+    iv = ss.str();
+    return iv;
 }
 
-bool aes_c::set_iv_key(const dynamic_mem_c &iv, const dynamic_mem_c &key)
-{
-	if (iv.empty() || key.empty())
-	{
-		ERROR("");
-		return false;
-	}
-	if (iv.size() != key.size())
-	{
-		ERROR("");
-		return false;
-	}
+void aes_c::set_key(string hex) {
+    // string buf(2, 0);
+    char buf[2] = {0};
+    char *bin = (char *)calloc(sizeof(char), hex.size());
+    int binsize = hex.size();
+    printf("binsize: %d\n", binsize);
 
-	for (size_t i = 0; i < iv.size(); i++)
-	{
-		this->iv.push_back(iv.mem_[i]);
-		this->key.push_back(key.mem_[i]);
-	}
-	return true;
+    this->remove_key();
+    char *pch;
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        buf[0] = hex[i];
+        buf[1] = hex[i + 1];
+        pch = buf;
+        bin[i / 2] = (char)strtoul(pch, NULL, 16);
+        this->key.push_back(bin[i / 2]);
+    }
+    free(bin);
+    bin = nullptr;
 }
 
-std::string aes_c::get_iv() const
-{
-	string iv;
-	stringstream ss;
-	char tch[10];
-	for (const auto &i : this->iv)
-	{
-		sprintf(tch, "%02x", (int)i);
-		ss << tch;
-	}
-	iv = ss.str();
-	return iv;
+void aes_c::remove_key() {
+    this->key.erase(this->key.begin(), this->key.end());
 }
 
-void aes_c::set_key(string hex)
-{
-	// string buf(2, 0);
-	char buf[2] = {0};
-	char *bin = (char *)calloc(sizeof(char), hex.size());
-	int binsize = hex.size();
-	printf("binsize: %d\n", binsize);
+void aes_c::remove_iv() { this->iv.erase(this->iv.begin(), this->iv.end()); }
 
-	this->remove_key();
-	char *pch;
-	for (size_t i = 0; i < hex.size(); i += 2)
-	{
-		buf[0] = hex[i];
-		buf[1] = hex[i + 1];
-		pch = buf;
-		bin[i / 2] = (char)strtoul(pch, NULL, 16);
-		this->key.push_back(bin[i / 2]);
-	}
-	free(bin);
-	bin = nullptr;
+std::string aes_c::get_key() const {
+    string key;
+    stringstream ss;
+    char tch[10];
+    for (const auto &i : this->key) {
+        sprintf(tch, "%02x", (int)i);
+        ss << tch;
+    }
+    key = ss.str();
+    return key;
 }
 
-void aes_c::remove_key()
-{
-	this->key.erase(this->key.begin(), this->key.end());
+void aes_c::create_key(int bit) {
+    this->key.erase(this->key.begin(), this->key.end());
+    unsigned char buf[bit / 8];
+    memset(buf, 0, sizeof(buf));
+    RAND_bytes(buf, bit / 8);
+    for (int i = 0; i < bit / 8; i++) {
+        this->key.push_back(buf[i]);
+    }
 }
 
-void aes_c::remove_iv()
-{
-	this->iv.erase(this->iv.begin(), this->iv.end());
+void aes_c::create_iv(int bit) {
+    this->iv.erase(this->iv.begin(), this->iv.end());
+    unsigned char buf[bit / 8];
+    memset(buf, 0, sizeof(buf));
+    RAND_bytes(buf, bit / 8);
+    for (int i = 0; i < bit / 8; i++) {
+        this->iv.push_back(buf[i]);
+    }
 }
 
-std::string aes_c::get_key() const
-{
-	string key;
-	stringstream ss;
-	char tch[10];
-	for (const auto &i : this->key)
-	{
-		sprintf(tch, "%02x", (int)i);
-		ss << tch;
-	}
-	key = ss.str();
-	return key;
+void aes_c::print_0x(const string header, const string &buf) const {
+    cout << header;
+    for (size_t i = 0; i < buf.size(); i++) {
+        printf("%02x", (unsigned char)buf[i]);
+    }
+    puts("");
 }
 
-void aes_c::create_key(int bit)
-{
-	this->key.erase(this->key.begin(), this->key.end());
-	unsigned char buf[bit / 8];
-	memset(buf, 0, sizeof(buf));
-	RAND_bytes(buf, bit / 8);
-	for (int i = 0; i < bit / 8; i++)
-	{
-		this->key.push_back(buf[i]);
-	}
+string aes_c::ui2hex(const vector<uint8_t> src) const {
+    stringstream buf;
+    for (size_t i = 0; i < src.size(); i++) {
+        buf << hex << int(src[i]);
+    }
+    return buf.str();
 }
 
-void aes_c::create_iv(int bit)
-{
-	this->iv.erase(this->iv.begin(), this->iv.end());
-	unsigned char buf[bit / 8];
-	memset(buf, 0, sizeof(buf));
-	RAND_bytes(buf, bit / 8);
-	for (int i = 0; i < bit / 8; i++)
-	{
-		this->iv.push_back(buf[i]);
-	}
+string aes_c::str2hex(const string src) const {
+    stringstream buf;
+    char p[10];
+    for (size_t i = 0; i < src.size(); i++) {
+        sprintf(p, "%02x", (unsigned char)src[i]);
+        buf << p;
+    }
+    return buf.str();
 }
 
-void aes_c::print_0x(const string header, const string &buf) const
-{
-	cout << header;
-	for (size_t i = 0; i < buf.size(); i++)
-	{
-		printf("%02x", (unsigned char)buf[i]);
-	}
-	puts("");
-}
+string aes_c::hex2str(const string hex) const {
+    char buf[3] = {0};
+    unsigned char *bin = (unsigned char *)calloc(sizeof(char), hex.size());
 
-string aes_c::ui2hex(const vector<uint8_t> src) const
-{
-	stringstream buf;
-	for (size_t i = 0; i < src.size(); i++)
-	{
-		buf << hex << int(src[i]);
-	}
-	return buf.str();
-}
-
-string aes_c::str2hex(const string src) const
-{
-	stringstream buf;
-	char p[10];
-	for (size_t i = 0; i < src.size(); i++)
-	{
-		sprintf(p, "%02x", (unsigned char)src[i]);
-		buf << p;
-	}
-	return buf.str();
-}
-
-string aes_c::hex2str(const string hex) const
-{
-	char buf[3] = {0};
-	unsigned char *bin = (unsigned char *)calloc(sizeof(char), hex.size());
-
-	string result;
-	result.erase(result.begin(), result.end());
-	char *pch;
-	memset((void *)bin, 0, hex.size());
-	for (size_t i = 0; i < hex.size(); i += 2)
-	{
-		buf[0] = hex[i];
-		buf[1] = hex[i + 1];
-		pch = buf;
+    string result;
+    result.erase(result.begin(), result.end());
+    char *pch;
+    memset((void *)bin, 0, hex.size());
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        buf[0] = hex[i];
+        buf[1] = hex[i + 1];
+        pch = buf;
 #if 1
-		bin[i / 2] = (unsigned char)strtoul(pch, NULL, 16);
-		cout << "strtoil: " << strtoul(pch, NULL, 16) << endl;
-		// result[i / 2] = char_out;
-		// result[i / 2 + 1] = NULL;
-		// result.push_back(char_out);
-		result.push_back(bin[i / 2]);
+        bin[i / 2] = (unsigned char)strtoul(pch, NULL, 16);
+        cout << "strtoil: " << strtoul(pch, NULL, 16) << endl;
+        // result[i / 2] = char_out;
+        // result[i / 2 + 1] = NULL;
+        // result.push_back(char_out);
+        result.push_back(bin[i / 2]);
 #else
-		bin[i / 2] = (char)strtoul(pch, NULL, 16);
-		//        result.push_back(bin[i / 2]);
-		result = result + bin[i / 2];
-		this->print_0x("0x: ", result);
+        bin[i / 2] = (char)strtoul(pch, NULL, 16);
+        //        result.push_back(bin[i / 2]);
+        result = result + bin[i / 2];
+        this->print_0x("0x: ", result);
 #endif
-	}
-	free(bin);
-	bin = nullptr;
-	return result;
+    }
+    free(bin);
+    bin = nullptr;
+    return result;
 }
 
 // std::vector<uint8_t> aes_c::hex2ui8(const string src) const
@@ -211,281 +179,255 @@ string aes_c::hex2str(const string hex) const
 //     return buf.str();
 // }
 
-void aes_c::encrypt(string &out, const string in, const AES_bit_e bit)
-{
+void aes_c::encrypt(string &out, const string in, const AES_bit_e bit) {
+    int out_len, in_len = in.size();
+    EVP_CIPHER_CTX *ctx;
 
-	int out_len, in_len = in.size();
-	EVP_CIPHER_CTX *ctx;
+    unsigned char *in2aes = (unsigned char *)in.data();
+    unsigned char *outFromAes =
+        (unsigned char *)calloc(sizeof(unsigned char), in.size());
 
-	unsigned char *in2aes = (unsigned char *)in.data();
-	unsigned char *outFromAes = (unsigned char *)calloc(sizeof(unsigned char), in.size());
+    if (key.empty()) {
+        ERROR("key empty");
+        return;
+    }
+    if (this->iv.empty()) {
+        ERROR("iv empty");
+        return;
+    }
+    u_int8_t *key2aes = (u_int8_t *)this->key.data();
+    u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
 
-	if (key.empty())
-	{
-		ERROR("key empty");
-		return;
-	}
-	if (this->iv.empty())
-	{
-		ERROR("iv empty");
-		return;
-	}
-	u_int8_t *key2aes = (u_int8_t *)this->key.data();
-	u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        printf("error EVP_CIPHER_CTX_new\n");
+        return;
+    }
 
-	if (!(ctx = EVP_CIPHER_CTX_new()))
-	{
-		printf("error EVP_CIPHER_CTX_new\n");
-		return;
-	}
+    switch (bit) {
+        case AES_bit_e::aes_128:
+            if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_EncryptInit_ex\n");
+                return;
+            }
+            break;
+        case AES_bit_e::aes_256:
+            if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_EncryptInit_ex\n");
+                return;
+            }
+            break;
 
-	switch (bit)
-	{
-	case AES_bit_e::aes_128:
-		if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_EncryptInit_ex\n");
-			return;
-		}
-		break;
-	case AES_bit_e::aes_256:
-		if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_EncryptInit_ex\n");
-			return;
-		}
-		break;
+        default:
+            break;
+    }
 
-	default:
-		break;
-	}
+    if (1 != EVP_EncryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len)) {
+        printf("error EVP_EncryptUpdate\n");
+        return;
+    }
+    if (out_len != in_len) {
+        printf("error encrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
+    }
 
-	if (1 != EVP_EncryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len))
-	{
-		printf("error EVP_EncryptUpdate\n");
-		return;
-	}
-	if (out_len != in_len)
-	{
-		printf("error encrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
-	}
+    EVP_CIPHER_CTX_free(ctx);
 
-	EVP_CIPHER_CTX_free(ctx);
+    for (size_t i = 0; i < in.size(); i++) {
+        out.push_back(outFromAes[i]);
+    }
 
-	for (size_t i = 0; i < in.size(); i++)
-	{
-		out.push_back(outFromAes[i]);
-	}
-
-	free(outFromAes);
-	outFromAes = nullptr;
+    free(outFromAes);
+    outFromAes = nullptr;
 }
 
-void aes_c::encrypt(dynamic_mem_c &out, const dynamic_mem_c &in, const AES_bit_e bit)
-{
+void aes_c::encrypt(dynamic_mem_c &out, const dynamic_mem_c &in,
+                    const AES_bit_e bit) {
+    // int out_len, in_len = in.size();
+    EVP_CIPHER_CTX *ctx;
 
-	// int out_len, in_len = in.size();
-	EVP_CIPHER_CTX *ctx;
+    if (key.empty()) {
+        ERROR("key empty");
+        return;
+    }
+    if (this->iv.empty()) {
+        ERROR("iv empty");
+        return;
+    }
+    u_int8_t *key2aes = (u_int8_t *)this->key.data();
+    u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
 
-	if (key.empty())
-	{
-		ERROR("key empty");
-		return;
-	}
-	if (this->iv.empty())
-	{
-		ERROR("iv empty");
-		return;
-	}
-	u_int8_t *key2aes = (u_int8_t *)this->key.data();
-	u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        printf("error EVP_CIPHER_CTX_new\n");
+        return;
+    }
 
-	if (!(ctx = EVP_CIPHER_CTX_new()))
-	{
-		printf("error EVP_CIPHER_CTX_new\n");
-		return;
-	}
+    switch (bit) {
+        case AES_bit_e::aes_128:
+            if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_EncryptInit_ex\n");
+                return;
+            }
+            break;
+        case AES_bit_e::aes_256:
+            if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_EncryptInit_ex\n");
+                return;
+            }
+            break;
 
-	switch (bit)
-	{
-	case AES_bit_e::aes_128:
-		if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_EncryptInit_ex\n");
-			return;
-		}
-		break;
-	case AES_bit_e::aes_256:
-		if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_EncryptInit_ex\n");
-			return;
-		}
-		break;
+        default:
+            break;
+    }
 
-	default:
-		break;
-	}
+    int size2aes = (int)in.size();
+    unsigned char *in2aes = (unsigned char *)in.mem_;
+    unsigned char *outFromAes =
+        (unsigned char *)calloc(sizeof(unsigned char), out.size());
 
-	int size2aes = (int)in.size();
-	unsigned char *in2aes = (unsigned char *)in.mem_;
-	unsigned char *outFromAes = (unsigned char *)calloc(sizeof(unsigned char), out.size());
+    if (1 != EVP_EncryptUpdate(ctx, outFromAes, &size2aes, in2aes, in.size())) {
+        printf("error EVP_EncryptUpdate\n");
+        return;
+    }
+    if (size2aes != (int)in.size()) {
+        printf("error encrypt out_len(%d) != in_len(%ld)\n", size2aes,
+               in.size());
+    }
 
-	if (1 != EVP_EncryptUpdate(ctx, outFromAes, &size2aes, in2aes, in.size()))
-	{
-		printf("error EVP_EncryptUpdate\n");
-		return;
-	}
-	if (size2aes != (int)in.size())
-	{
-		printf("error encrypt out_len(%d) != in_len(%ld)\n", size2aes, in.size());
-	}
+    EVP_CIPHER_CTX_free(ctx);
 
-	EVP_CIPHER_CTX_free(ctx);
+    memcpy(out.mem_, outFromAes, out.size());
 
-	memcpy(out.mem_, outFromAes, out.size());
-
-	free(outFromAes);
-	outFromAes = nullptr;
+    free(outFromAes);
+    outFromAes = nullptr;
 }
 
-void aes_c::decrypt(string &out, const string in, const AES_bit_e bit)
-{
-	int out_len, in_len = in.size();
-	EVP_CIPHER_CTX *ctx;
+void aes_c::decrypt(string &out, const string in, const AES_bit_e bit) {
+    int out_len, in_len = in.size();
+    EVP_CIPHER_CTX *ctx;
 
-	if (key.empty())
-	{
-		ERROR("key empty");
-		return;
-	}
-	if (this->iv.empty())
-	{
-		ERROR("iv empty");
-		return;
-	}
+    if (key.empty()) {
+        ERROR("key empty");
+        return;
+    }
+    if (this->iv.empty()) {
+        ERROR("iv empty");
+        return;
+    }
 
-	unsigned char *in2aes = (unsigned char *)in.data();
-	u_int8_t *key2aes = (u_int8_t *)this->key.data();
-	u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
-	unsigned char *outFromAes = (unsigned char *)calloc(sizeof(unsigned char), in.size());
+    unsigned char *in2aes = (unsigned char *)in.data();
+    u_int8_t *key2aes = (u_int8_t *)this->key.data();
+    u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
+    unsigned char *outFromAes =
+        (unsigned char *)calloc(sizeof(unsigned char), in.size());
 
-	if (!(ctx = EVP_CIPHER_CTX_new()))
-	{
-		printf("error EVP_CIPHER_CTX_new\n");
-		return;
-	}
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        printf("error EVP_CIPHER_CTX_new\n");
+        return;
+    }
 
-	switch (bit)
-	{
-	case AES_bit_e::aes_128:
-		if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_DecryptInit_ex\n");
-			return;
-		}
-		break;
+    switch (bit) {
+        case AES_bit_e::aes_128:
+            if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_DecryptInit_ex\n");
+                return;
+            }
+            break;
 
-	case AES_bit_e::aes_256:
-		if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_DecryptInit_ex\n");
-			return;
-		}
-		break;
+        case AES_bit_e::aes_256:
+            if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_DecryptInit_ex\n");
+                return;
+            }
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	if (1 != EVP_DecryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len))
-	{
-		printf("error EVP_DecryptUpdate\n");
-		return;
-	}
-	if (out_len != in_len)
-	{
-		printf("error decrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
-	}
+    if (1 != EVP_DecryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len)) {
+        printf("error EVP_DecryptUpdate\n");
+        return;
+    }
+    if (out_len != in_len) {
+        printf("error decrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
+    }
 
-	EVP_CIPHER_CTX_free(ctx);
-	for (size_t i = 0; i < in.size(); i++)
-	{
-		out.push_back(outFromAes[i]);
-	}
+    EVP_CIPHER_CTX_free(ctx);
+    for (size_t i = 0; i < in.size(); i++) {
+        out.push_back(outFromAes[i]);
+    }
 
-	free(outFromAes);
-	outFromAes = nullptr;
+    free(outFromAes);
+    outFromAes = nullptr;
 }
 
-void aes_c::decrypt(dynamic_mem_c &out, const dynamic_mem_c &in, const AES_bit_e bit)
-{
-	int out_len, in_len = in.size();
-	EVP_CIPHER_CTX *ctx;
+void aes_c::decrypt(dynamic_mem_c &out, const dynamic_mem_c &in,
+                    const AES_bit_e bit) {
+    int out_len, in_len = in.size();
+    EVP_CIPHER_CTX *ctx;
 
-	if (key.empty())
-	{
-		ERROR("key empty");
-		return;
-	}
-	if (this->iv.empty())
-	{
-		ERROR("iv empty");
-		return;
-	}
+    if (key.empty()) {
+        ERROR("key empty");
+        return;
+    }
+    if (this->iv.empty()) {
+        ERROR("iv empty");
+        return;
+    }
 
-	u_int8_t *key2aes = (u_int8_t *)this->key.data();
-	u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
+    u_int8_t *key2aes = (u_int8_t *)this->key.data();
+    u_int8_t *iv2aes = (u_int8_t *)this->iv.data();
 
-	if (!(ctx = EVP_CIPHER_CTX_new()))
-	{
-		printf("error EVP_CIPHER_CTX_new\n");
-		return;
-	}
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        printf("error EVP_CIPHER_CTX_new\n");
+        return;
+    }
 
-	switch (bit)
-	{
-	case AES_bit_e::aes_128:
-		if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_DecryptInit_ex\n");
-			return;
-		}
-		break;
+    switch (bit) {
+        case AES_bit_e::aes_128:
+            if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_128_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_DecryptInit_ex\n");
+                return;
+            }
+            break;
 
-	case AES_bit_e::aes_256:
-		if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes, iv2aes))
-		{
-			printf("error EVP_DecryptInit_ex\n");
-			return;
-		}
-		break;
+        case AES_bit_e::aes_256:
+            if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_ctr(), NULL, key2aes,
+                                        iv2aes)) {
+                printf("error EVP_DecryptInit_ex\n");
+                return;
+            }
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	unsigned char *outFromAes = (unsigned char *)calloc(sizeof(unsigned char), in.size());
-	unsigned char *in2aes = (unsigned char *)in.mem_;
-	if (1 != EVP_DecryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len))
-	{
-		printf("error EVP_DecryptUpdate\n");
-		return;
-	}
-	if (out_len != in_len)
-	{
-		printf("error decrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
-	}
+    unsigned char *outFromAes =
+        (unsigned char *)calloc(sizeof(unsigned char), in.size());
+    unsigned char *in2aes = (unsigned char *)in.mem_;
+    if (1 != EVP_DecryptUpdate(ctx, outFromAes, &out_len, in2aes, in_len)) {
+        printf("error EVP_DecryptUpdate\n");
+        return;
+    }
+    if (out_len != in_len) {
+        printf("error decrypt out_len(%d) != in_len(%d)\n", out_len, in_len);
+    }
 
-	EVP_CIPHER_CTX_free(ctx);
-	memcpy(out.mem_, outFromAes, out.size());
+    EVP_CIPHER_CTX_free(ctx);
+    memcpy(out.mem_, outFromAes, out.size());
 
-	free(outFromAes);
-	outFromAes = nullptr;
+    free(outFromAes);
+    outFromAes = nullptr;
 }
 
-void aes_c::reset()
-{
-	this->key.erase(this->key.begin(), this->key.end());
-	this->iv.erase(this->iv.begin(), this->iv.end());
+void aes_c::reset() {
+    this->key.erase(this->key.begin(), this->key.end());
+    this->iv.erase(this->iv.begin(), this->iv.end());
 }

--- a/src/device_c.cpp
+++ b/src/device_c.cpp
@@ -1,148 +1,119 @@
 #include "../include/device_c.hpp"
 
-device_c::device_c()
-{
-}
+device_c::device_c() {}
 
-device_c::~device_c()
-{
-}
+device_c::~device_c() {}
 
 using namespace std;
 
-namespace local
-{
-	vector<string> cmdline2List(string cmd)
-	{
-		FILE *fp;
-		vector<string> cmdstring;
-		if ((fp = popen(cmd.c_str(), "r")) == NULL)
-		{
-			PRINT_ERROR_LOG("can not exec commad");
-			cmdstring.clear();
-			return cmdstring;
-		}
-		char cmd_buf[256];
-		while (fgetc(fp) != EOF)
-		{
-			fgets(cmd_buf, sizeof(cmd_buf), fp);
-			cmdstring.push_back(cmd_buf);
-		}
+namespace local {
+vector<string> cmdline2List(string cmd) {
+    FILE *fp;
+    vector<string> cmdstring;
+    if ((fp = popen(cmd.c_str(), "r")) == NULL) {
+        PRINT_ERROR_LOG("can not exec commad");
+        cmdstring.clear();
+        return cmdstring;
+    }
+    char cmd_buf[256];
+    while (fgetc(fp) != EOF) {
+        fgets(cmd_buf, sizeof(cmd_buf), fp);
+        cmdstring.push_back(cmd_buf);
+    }
 
-		if (cmdstring.empty())
-		{
-			PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
-			cmdstring.clear();
-			return cmdstring;
-		}
-		(void)pclose(fp);
+    if (cmdstring.empty()) {
+        PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
+        cmdstring.clear();
+        return cmdstring;
+    }
+    (void)pclose(fp);
 
-		// 改行文字を処理
-		for (string &in : cmdstring)
-		{
-			if (in.find("\n", 1) != string::npos)
-			{
-				in.erase(in.find("\n", 1), 1);
-			}
-		}
-		return cmdstring;
-	}
-	string cmdline(string cmd)
-	{
-		FILE *fp;
-		string cmdstring;
-		if ((fp = popen(cmd.c_str(), "r")) == NULL)
-		{
-			PRINT_ERROR_LOG("can not exec commad");
-			return "";
-		}
-		char cmd_buf[256];
-		fgets(cmd_buf, sizeof(cmd_buf), fp);
-		cmdstring += cmd_buf;
-
-		if (cmdstring.empty())
-		{
-			PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
-			return "";
-		}
-		(void)pclose(fp);
-
-		// 改行文字を処理
-		if (cmdstring.find("\n", 1) != string::npos)
-		{
-			cmdstring.erase(cmdstring.find("\n", 1), 1);
-		}
-		return cmdstring;
-	}
+    // 改行文字を処理
+    for (string &in : cmdstring) {
+        if (in.find("\n", 1) != string::npos) {
+            in.erase(in.find("\n", 1), 1);
+        }
+    }
+    return cmdstring;
 }
-vector<string> device_c::get_usbList() const
-{
-	string cmdline = "lsusb | cut -d ' ' -f 5- ";
-	std::vector<std::string> usb_list;
-	usb_list = local::cmdline2List(cmdline);
-	return usb_list;
+string cmdline(string cmd) {
+    FILE *fp;
+    string cmdstring;
+    if ((fp = popen(cmd.c_str(), "r")) == NULL) {
+        PRINT_ERROR_LOG("can not exec commad");
+        return "";
+    }
+    char cmd_buf[256];
+    fgets(cmd_buf, sizeof(cmd_buf), fp);
+    cmdstring += cmd_buf;
+
+    if (cmdstring.empty()) {
+        PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
+        return "";
+    }
+    (void)pclose(fp);
+
+    // 改行文字を処理
+    if (cmdstring.find("\n", 1) != string::npos) {
+        cmdstring.erase(cmdstring.find("\n", 1), 1);
+    }
+    return cmdstring;
+}
+}  // namespace local
+vector<string> device_c::get_usbList() const {
+    string cmdline = "lsusb | cut -d ' ' -f 5- ";
+    std::vector<std::string> usb_list;
+    usb_list = local::cmdline2List(cmdline);
+    return usb_list;
 }
 
-bool device_c::set_usbID(const string usbID)
-{
-	if (usbID.empty() || usbID.size() != 9)
-	{
-		PRINT_ERROR_LOG("usbIDが不正");
-		return false;
-	}
-	// sudo lsusb -d 1d6b:0002 -v | grep iSerial | awk '{print $3}'
-	string cmdline = "sudo lsusb -d ";
-	cmdline += usbID;
-	cmdline += " -v | grep iSerial | awk '{print $3}' | tail -n -1";
+bool device_c::set_usbID(const string usbID) {
+    if (usbID.empty() || usbID.size() != 9) {
+        PRINT_ERROR_LOG("usbIDが不正");
+        return false;
+    }
+    // sudo lsusb -d 1d6b:0002 -v | grep iSerial | awk '{print $3}'
+    string cmdline = "sudo lsusb -d ";
+    cmdline += usbID;
+    cmdline += " -v | grep iSerial | awk '{print $3}' | tail -n -1";
 
-	string temp = local::cmdline(cmdline);
-	try
-	{
-		// 4文字未満のシリアル番号はエラーとみなす
-		if (temp.empty() || temp.size() < 4)
-		{
-			PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
-			return false;
-		}
-		else
-		{
-			if (temp.find("\n", 1) != string::npos)
-			{
-				temp.erase(temp.find("\n", 1));
-			}
-			this->usb_serial_ = temp;
-			this->usb_id_ = usbID;
-		}
-	}
-	catch (const std::exception &e)
-	{
-		std::cerr << e.what() << '\n';
-		PRINT_ERROR_LOG(e.what());
-	}
+    string temp = local::cmdline(cmdline);
+    try {
+        // 4文字未満のシリアル番号はエラーとみなす
+        if (temp.empty() || temp.size() < 4) {
+            PRINT_ERROR_LOG("コマンドラインから出力を得られませんでした");
+            return false;
+        } else {
+            if (temp.find("\n", 1) != string::npos) {
+                temp.erase(temp.find("\n", 1));
+            }
+            this->usb_serial_ = temp;
+            this->usb_id_ = usbID;
+        }
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << '\n';
+        PRINT_ERROR_LOG(e.what());
+    }
 
-	return true;
+    return true;
 }
 
-string device_c::get_usbID() const
-{
-	if (this->usb_id_.empty())
-	{
-		return "";
-	}
-	return this->usb_id_;
+string device_c::get_usbID() const {
+    if (this->usb_id_.empty()) {
+        return "";
+    }
+    return this->usb_id_;
 }
 
-string device_c::get_usbSerial() const
-{
-	if (this->usb_serial_.empty())
-	{
-		return "";
-	}
-	return this->usb_serial_;
+string device_c::get_usbSerial() const {
+    if (this->usb_serial_.empty()) {
+        return "";
+    }
+    return this->usb_serial_;
 }
 
-uint32_t device_c::get_usb_cnt() const
-{
-	uint32_t usb_size = static_cast<uint32_t>(stoi(local::cmdline("lsusb | wc -l")));
-	return usb_size;
+uint32_t device_c::get_usb_cnt() const {
+    uint32_t usb_size =
+        static_cast<uint32_t>(stoi(local::cmdline("lsusb | wc -l")));
+    return usb_size;
 }

--- a/src/dynamic_mem_c.cpp
+++ b/src/dynamic_mem_c.cpp
@@ -1,41 +1,31 @@
 #include "../include/dynamic_mem_c.hpp"
 
-dynamic_mem_c::dynamic_mem_c()
-{
+dynamic_mem_c::dynamic_mem_c() {
     this->size_ = 0;
     this->mem_ = nullptr;
 }
-dynamic_mem_c::dynamic_mem_c(const uint size)
-{
+dynamic_mem_c::dynamic_mem_c(const uint size) {
     this->size_ = size;
-    try
-    {
+    try {
         this->mem_ = new u_char[size];
-    }
-    catch (std::bad_alloc)
-    {
+    } catch (std::bad_alloc) {
         ERROR("");
     }
     memset(this->mem_, 0, size);
 }
 
-dynamic_mem_c::~dynamic_mem_c()
-{
-    if (this->mem_)
-    {
+dynamic_mem_c::~dynamic_mem_c() {
+    if (this->mem_) {
         delete this->mem_;
     }
 }
 
-dynamic_mem_c::dynamic_mem_c(const dynamic_mem_c &from)
-{
+dynamic_mem_c::dynamic_mem_c(const dynamic_mem_c &from) {
     size_ = from.size_;
-    if (from.size_ > 0)
-    {
+    if (from.size_ > 0) {
         mem_ = new u_char[size_];
     }
-    for (size_t i = 0; i < size_; i++)
-    {
+    for (size_t i = 0; i < size_; i++) {
         mem_[i] = from.mem_[i];
     }
     return;
@@ -43,38 +33,30 @@ dynamic_mem_c::dynamic_mem_c(const dynamic_mem_c &from)
 
 using namespace std;
 
-dynamic_mem_c &dynamic_mem_c::operator=(const dynamic_mem_c &from)
-{
-    if (this == &from)
-    {
+dynamic_mem_c &dynamic_mem_c::operator=(const dynamic_mem_c &from) {
+    if (this == &from) {
         return *this;
     }
 
-    if (from.size() == 0)
-    {
+    if (from.size() == 0) {
         return *this;
     }
 
-    if (this->size() != from.size())
-    {
+    if (this->size() != from.size()) {
         this->size_ = from.size();
-        if (this->mem_ != nullptr)
-        {
+        if (this->mem_ != nullptr) {
             delete this->mem_;
         }
         this->mem_ = new u_char[this->size()];
     }
-    for (size_t i = 0; i < this->size(); i++)
-    {
+    for (size_t i = 0; i < this->size(); i++) {
         this->mem_[i] = from.mem_[i];
     }
     return *this;
 }
 
-void dynamic_mem_c::d_new(const uint size)
-{
-    if (this->mem_)
-    {
+void dynamic_mem_c::d_new(const uint size) {
+    if (this->mem_) {
         delete this->mem_;
         this->mem_ = nullptr;
     }
@@ -83,57 +65,42 @@ void dynamic_mem_c::d_new(const uint size)
     this->size_ = size;
 }
 
-void dynamic_mem_c::d_free()
-{
-    if (this->mem_)
-    {
+void dynamic_mem_c::d_free() {
+    if (this->mem_) {
         delete this->mem_;
         this->mem_ = nullptr;
     }
     this->size_ = 0;
 }
 
-size_t dynamic_mem_c::size() const
-{
-    return this->size_;
-}
+size_t dynamic_mem_c::size() const { return this->size_; }
 
-void dynamic_mem_c::copy(string &dest, const uint size) const
-{
-    if (this->mem_)
-    {
-        for (uint i = 0; i < size; i++)
-        {
+void dynamic_mem_c::copy(string &dest, const uint size) const {
+    if (this->mem_) {
+        for (uint i = 0; i < size; i++) {
             dest.push_back(this->mem_[i]);
         }
     }
 }
 
-void dynamic_mem_c::reset()
-{
-    if (this->mem_)
-    {
+void dynamic_mem_c::reset() {
+    if (this->mem_) {
         memset(this->mem_, 0, this->size());
     }
 }
 
-bool dynamic_mem_c::empty() const
-{
-    if (this->size() == 0 || this->mem_ == nullptr)
-    {
+bool dynamic_mem_c::empty() const {
+    if (this->size() == 0 || this->mem_ == nullptr) {
         return true;
     }
     bool isEmpty = true;
-    for (size_t i = 0; i < this->size(); i++)
-    {
-        if (this->mem_[i] != 0)
-        {
+    for (size_t i = 0; i < this->size(); i++) {
+        if (this->mem_[i] != 0) {
             isEmpty = false;
             break;
         }
     }
-    if (isEmpty == true)
-    {
+    if (isEmpty == true) {
         return true;
     }
     return false;

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -2,29 +2,27 @@
 
 using namespace std;
 
-void push_error_log(const char *comment, const char *file, const char *func, const int line)
-{
-	time_t timer;
-	struct tm *date;
+void push_error_log(const char *comment, const char *file, const char *func,
+                    const int line) {
+    time_t timer;
+    struct tm *date;
 
-	string message;
-	ofstream ofp(ERROR_LOG_FILE, ios_base::app);
-	if (!ofp)
-	{
-		ERROR_NO_COMMENT;
-		return;
-	}
+    string message;
+    ofstream ofp(ERROR_LOG_FILE, ios_base::app);
+    if (!ofp) {
+        ERROR_NO_COMMENT;
+        return;
+    }
 
-	/* 時間取得 */
-	timer = time(NULL);
-	date = localtime(&timer);
-	char buf[512] = {"0"};
-	strftime(buf, sizeof(buf), "[%Y/%x %H:%M:%S] ", date);
+    /* 時間取得 */
+    timer = time(NULL);
+    date = localtime(&timer);
+    char buf[512] = {"0"};
+    strftime(buf, sizeof(buf), "[%Y/%x %H:%M:%S] ", date);
 
-	// ファイル出力
-	ofp << buf << "\n\t";
-	ofp << "[" << file << ", " << func << ", " << line << "]"
-		<< "\n\t\t";
-	ofp << comment << "\n"
-		<< endl;
+    // ファイル出力
+    ofp << buf << "\n\t";
+    ofp << "[" << file << ", " << func << ", " << line << "]"
+        << "\n\t\t";
+    ofp << comment << "\n" << endl;
 }

--- a/src/file_enc.cpp
+++ b/src/file_enc.cpp
@@ -2,339 +2,292 @@
 
 using namespace std;
 
-file_enc_c::file_enc_c()
-{
-	this->isDir_ = false;
-	this->isFile_ = false;
-	this->isEncrypt_ = false;
-	this->isNoEncrypt_ = false;
-	this->isExit_ = false;
+file_enc_c::file_enc_c() {
+    this->isDir_ = false;
+    this->isFile_ = false;
+    this->isEncrypt_ = false;
+    this->isNoEncrypt_ = false;
+    this->isExit_ = false;
 }
 
-file_enc_c::~file_enc_c()
-{
+file_enc_c::~file_enc_c() {}
+
+bool file_enc_c::set_file_path(string filepath) {
+    if (filepath.size() > FILE_PATH_SIZE_LIM) {
+        ERROR("ファイルパスが長すぎます");
+        return false;
+    }
+    this->file_path_ = filepath;
+
+    if (this->file_path_.find("\n") != string::npos) {
+        this->file_path_.erase(this->file_path_.find("\n"), 1);
+    }
+    if (this->file_path_.find("\r") != string::npos) {
+        this->file_path_.erase(this->file_path_.find("\r"), 1);
+    }
+
+    fstream input_fs(this->file_path_);
+    if (!input_fs) {
+        ERROR("ファイルオープンに失敗");
+        cerr << "filepath: " << this->file_path_ << endl;
+        return false;
+    }
+
+    string buf;
+    getline(input_fs, buf);
+    if (!input_fs) {
+        ERROR("読み取りに失敗");
+        cerr << "filepath: " << this->file_path_ << endl;
+        return false;
+    }
+
+    this->isFile_ = true;
+    this->isExit_ = true;
+
+    return true;
 }
 
-bool file_enc_c::set_file_path(string filepath)
-{
-	if (filepath.size() > FILE_PATH_SIZE_LIM)
-	{
-		ERROR("ファイルパスが長すぎます");
-		return false;
-	}
-	this->file_path_ = filepath;
-
-	if (this->file_path_.find("\n") != string::npos)
-	{
-		this->file_path_.erase(this->file_path_.find("\n"), 1);
-	}
-	if (this->file_path_.find("\r") != string::npos)
-	{
-		this->file_path_.erase(this->file_path_.find("\r"), 1);
-	}
-
-	fstream input_fs(this->file_path_);
-	if (!input_fs)
-	{
-		ERROR("ファイルオープンに失敗");
-		cerr << "filepath: " << this->file_path_ << endl;
-		return false;
-	}
-
-	string buf;
-	getline(input_fs, buf);
-	if (!input_fs)
-	{
-		ERROR("読み取りに失敗");
-		cerr << "filepath: " << this->file_path_ << endl;
-		return false;
-	}
-
-	this->isFile_ = true;
-	this->isExit_ = true;
-
-	return true;
+bool file_enc_c::is_file_exit() const {
+    if (this->isFile_ && this->isExit_) {
+        return true;
+    }
+    return false;
 }
 
-bool file_enc_c::is_file_exit() const
-{
-	if (this->isFile_ && this->isExit_)
-	{
-		return true;
-	}
-	return false;
+bool file_enc_c::set_password(string pass) {
+    if (pass.size() == 0) {
+        ERROR("パスワードが入力されていません");
+        return false;
+    }
+    if (pass.find("\n") != string::npos) {
+        pass.erase(pass.find("\n"), 1);
+    }
+    if (pass.find("\r") != string::npos) {
+        pass.erase(pass.find("\r"), 1);
+    }
+    if (pass.size() == 0) {
+        ERROR("パスワード入力が不正です");
+        return false;
+    }
+    this->password_ = pass;
+    return true;
 }
 
-bool file_enc_c::set_password(string pass)
-{
-	if (pass.size() == 0)
-	{
-		ERROR("パスワードが入力されていません");
-		return false;
-	}
-	if (pass.find("\n") != string::npos)
-	{
-		pass.erase(pass.find("\n"), 1);
-	}
-	if (pass.find("\r") != string::npos)
-	{
-		pass.erase(pass.find("\r"), 1);
-	}
-	if (pass.size() == 0)
-	{
-		ERROR("パスワード入力が不正です");
-		return false;
-	}
-	this->password_ = pass;
-	return true;
-}
+bool file_enc_c::file_enc() {
+    if (this->file_path_.size() == 0 || this->is_file_exit() == false) {
+        ERROR("");
+        return false;
+    }
 
-bool file_enc_c::file_enc()
-{
-	if (this->file_path_.size() == 0 ||
-		this->is_file_exit() == false)
-	{
-		ERROR("");
-		return false;
-	}
+    fstream fs(this->file_path_);
+    if (!fs) {
+        ERROR("ファイルオープンに失敗");
+        cerr << "filepath: " << this->file_path_ << endl;
+        return false;
+    }
 
-	fstream fs(this->file_path_);
-	if (!fs)
-	{
-		ERROR("ファイルオープンに失敗");
-		cerr << "filepath: " << this->file_path_ << endl;
-		return false;
-	}
-
-	SHA_c sha;
-	aes_c aes;
+    SHA_c sha;
+    aes_c aes;
 #if 0
 	this->safe_pass_ = sha.sha2_cal(this->password_, SHA_c::SHA2_bit::SHA_256);
 
 	aes.set_iv(sha.str2hex(this->safe_pass_));
 	aes.set_key(sha.str2hex(this->safe_pass_));
 #else
-	dynamic_mem_c iv(HASH_SIZE), key(HASH_SIZE);
-	RAND_bytes(iv.mem_, iv.size());
-	RAND_bytes(key.mem_, key.size());
-	aes.set_iv_key(iv, key);
+    dynamic_mem_c iv(HASH_SIZE), key(HASH_SIZE);
+    RAND_bytes(iv.mem_, iv.size());
+    RAND_bytes(key.mem_, key.size());
+    aes.set_iv_key(iv, key);
 
 #endif
 
-	if (this->crypt_process(aes, file_enc_c::CRYPT_MODE::ENCRYPT) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+    if (this->crypt_process(aes, file_enc_c::CRYPT_MODE::ENCRYPT) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	key_list_c key_list;
-	dynamic_mem_c hash(HASH_SIZE);
-	if (this->calc_file_hash(this->get_file_pass(), hash) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+    key_list_c key_list;
+    dynamic_mem_c hash(HASH_SIZE);
+    if (this->calc_file_hash(this->get_file_pass(), hash) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	if (key_list.add_file(hash, iv, key) == false)
-	{
-		ERROR("鍵リストへの登録に失敗しました");
-		return false;
-	}
+    if (key_list.add_file(hash, iv, key) == false) {
+        ERROR("鍵リストへの登録に失敗しました");
+        return false;
+    }
 
-	this->extemsion_set(file_enc_c::CRYPT_MODE::ENCRYPT);
-	cout << "暗号化に成功" << endl;
-	return true;
+    this->extemsion_set(file_enc_c::CRYPT_MODE::ENCRYPT);
+    cout << "暗号化に成功" << endl;
+    return true;
 }
 
-bool file_enc_c::file_dec()
-{
-	// エラーチェック
-	if (this->file_path_.size() == 0 ||
-		this->is_file_exit() == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+bool file_enc_c::file_dec() {
+    // エラーチェック
+    if (this->file_path_.size() == 0 || this->is_file_exit() == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	fstream fs(this->file_path_);
-	if (!fs)
-	{
-		ERROR("ファイルオープンに失敗");
-		cerr << "filepath: " << this->file_path_ << endl;
-		return false;
-	}
+    fstream fs(this->file_path_);
+    if (!fs) {
+        ERROR("ファイルオープンに失敗");
+        cerr << "filepath: " << this->file_path_ << endl;
+        return false;
+    }
 
-	// パスワードのハッシュを鍵とivに使用
-	SHA_c sha;
-	aes_c aes;
+    // パスワードのハッシュを鍵とivに使用
+    SHA_c sha;
+    aes_c aes;
 #if 0
 	this->safe_pass_ = sha.sha2_cal(this->password_, SHA_c::SHA2_bit::SHA_256);
 	aes.set_iv(sha.str2hex(this->safe_pass_));
 	aes.set_key(sha.str2hex(this->safe_pass_));
 #else
-	dynamic_mem_c hash(HASH_SIZE), iv(AES_SIZE), key(AES_SIZE);
-	if (this->calc_file_hash(this->get_file_pass(), hash) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	key_list_c key_list;
-	if (key_list.pop_file(hash, iv, key) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	aes.set_iv_key(iv, key);
+    dynamic_mem_c hash(HASH_SIZE), iv(AES_SIZE), key(AES_SIZE);
+    if (this->calc_file_hash(this->get_file_pass(), hash) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    key_list_c key_list;
+    if (key_list.pop_file(hash, iv, key) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    aes.set_iv_key(iv, key);
 #endif
 
-	if (this->crypt_process(aes, file_enc_c::CRYPT_MODE::DECRYPT) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+    if (this->crypt_process(aes, file_enc_c::CRYPT_MODE::DECRYPT) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	this->extemsion_set(file_enc_c::CRYPT_MODE::DECRYPT);
-	cout << "復号に成功" << endl;
-	return true;
+    this->extemsion_set(file_enc_c::CRYPT_MODE::DECRYPT);
+    cout << "復号に成功" << endl;
+    return true;
 }
 
-string file_enc_c::get_file_pass() const
-{
-	return this->file_path_;
-}
+string file_enc_c::get_file_pass() const { return this->file_path_; }
 
 // ファイルポインタは先頭にして返す
-size_t file_enc_c::getFileSize(FILE *fp) const
-{
-	if (fp == NULL)
-	{
-		return -1;
-	}
+size_t file_enc_c::getFileSize(FILE *fp) const {
+    if (fp == NULL) {
+        return -1;
+    }
 
-	if (fseek(fp, 0L, SEEK_END) != 0)
-	{
-		return -1;
-	}
-	size_t file_size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
-	return file_size;
+    if (fseek(fp, 0L, SEEK_END) != 0) {
+        return -1;
+    }
+    size_t file_size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    return file_size;
 }
 
-void file_enc_c::file_delete(string const file_path) const
-{
-	file_ptr_c fp(file_path.c_str(), "wb");
+void file_enc_c::file_delete(string const file_path) const {
+    file_ptr_c fp(file_path.c_str(), "wb");
 }
 
-bool file_enc_c::crypt_process(aes_c &aes, file_enc_c::CRYPT_MODE const mode) const
-{
-	const int BUF_SIZE = 2048;
-	const string buff_file_name(CRYPT_BUFFER_FILE);
+bool file_enc_c::crypt_process(aes_c &aes,
+                               file_enc_c::CRYPT_MODE const mode) const {
+    const int BUF_SIZE = 2048;
+    const string buff_file_name(CRYPT_BUFFER_FILE);
 
-	dynamic_mem_c buf;
-	buf.d_new(BUF_SIZE);
+    dynamic_mem_c buf;
+    buf.d_new(BUF_SIZE);
 
-	file_ptr_c FP(this->get_file_pass().c_str(), "rb");
+    file_ptr_c FP(this->get_file_pass().c_str(), "rb");
 
-	// バッファ用ファイルを作成
-	file_ptr_c FP_buffer(buff_file_name.c_str(), "wb");
+    // バッファ用ファイルを作成
+    file_ptr_c FP_buffer(buff_file_name.c_str(), "wb");
 
-	int read_size = 0;
+    int read_size = 0;
 
-	dynamic_mem_c out_buf;
-	out_buf.d_new(BUF_SIZE);
+    dynamic_mem_c out_buf;
+    out_buf.d_new(BUF_SIZE);
 
-	// 暗号化/復号
-	switch (mode)
-	{
-	case file_enc_c::CRYPT_MODE::ENCRYPT:
-		while ((read_size = fread(buf.mem_, 1, 1024, FP.fp_)) > 0)
-		{
-			aes.encrypt(out_buf, buf, aes_c::AES_bit_e::aes_256);
-			fwrite(out_buf.mem_, 1, read_size, FP_buffer.fp_);
-			// out_buf.reset();
-			buf.reset();
-		}
-		break;
+    // 暗号化/復号
+    switch (mode) {
+        case file_enc_c::CRYPT_MODE::ENCRYPT:
+            while ((read_size = fread(buf.mem_, 1, 1024, FP.fp_)) > 0) {
+                aes.encrypt(out_buf, buf, aes_c::AES_bit_e::aes_256);
+                fwrite(out_buf.mem_, 1, read_size, FP_buffer.fp_);
+                // out_buf.reset();
+                buf.reset();
+            }
+            break;
 
-	case file_enc_c::CRYPT_MODE::DECRYPT:
-		while ((read_size = fread(buf.mem_, 1, 1024, FP.fp_)) > 0)
-		{
-			aes.decrypt(out_buf, buf, aes_c::AES_bit_e::aes_256);
-			fwrite(out_buf.mem_, 1, read_size, FP_buffer.fp_);
-			out_buf.reset();
-			buf.reset();
-		}
-		break;
+        case file_enc_c::CRYPT_MODE::DECRYPT:
+            while ((read_size = fread(buf.mem_, 1, 1024, FP.fp_)) > 0) {
+                aes.decrypt(out_buf, buf, aes_c::AES_bit_e::aes_256);
+                fwrite(out_buf.mem_, 1, read_size, FP_buffer.fp_);
+                out_buf.reset();
+                buf.reset();
+            }
+            break;
 
-	default:
-		ERROR("");
-		break;
-	}
+        default:
+            ERROR("");
+            break;
+    }
 
-	// ファイル出力
-	FP.reopen(this->get_file_pass().c_str(), "wb");
-	FP_buffer.reopen(buff_file_name.c_str(), "rb");
+    // ファイル出力
+    FP.reopen(this->get_file_pass().c_str(), "wb");
+    FP_buffer.reopen(buff_file_name.c_str(), "rb");
 
-	while ((read_size = fread(buf.mem_, 1, 1024, FP_buffer.fp_)) > 0)
-	{
-		fwrite(buf.mem_, 1, read_size, FP.fp_);
-	}
-	this->file_delete(buff_file_name);
+    while ((read_size = fread(buf.mem_, 1, 1024, FP_buffer.fp_)) > 0) {
+        fwrite(buf.mem_, 1, read_size, FP.fp_);
+    }
+    this->file_delete(buff_file_name);
 
-	return true;
+    return true;
 }
 
-bool file_enc_c::calc_file_hash(const string file_name, dynamic_mem_c &out) const
-{
-	file_ptr_c FP;
-	FP.open(file_name, "rb");
+bool file_enc_c::calc_file_hash(const string file_name,
+                                dynamic_mem_c &out) const {
+    file_ptr_c FP;
+    FP.open(file_name, "rb");
 
-	fseek(FP.fp_, 0, SEEK_END);
-	size_t file_size = ftell(FP.fp_);
-	dynamic_mem_c buffer(file_size);
+    fseek(FP.fp_, 0, SEEK_END);
+    size_t file_size = ftell(FP.fp_);
+    dynamic_mem_c buffer(file_size);
 
-	rewind(FP.fp_);
-	fread(buffer.mem_, 1, file_size, FP.fp_);
-	dynamic_mem_c hash(HASH_SIZE);
+    rewind(FP.fp_);
+    fread(buffer.mem_, 1, file_size, FP.fp_);
+    dynamic_mem_c hash(HASH_SIZE);
 
-	SHA_c sha;
-	sha.sha2_cal(buffer, hash, SHA_c::SHA2_bit::SHA_256);
-	if (out.size() < hash.size())
-	{
-		return false;
-	}
-	memcpy(out.mem_, hash.mem_, hash.size());
-	return true;
+    SHA_c sha;
+    sha.sha2_cal(buffer, hash, SHA_c::SHA2_bit::SHA_256);
+    if (out.size() < hash.size()) {
+        return false;
+    }
+    memcpy(out.mem_, hash.mem_, hash.size());
+    return true;
 }
 
-void file_enc_c::extemsion_set(const file_enc_c::CRYPT_MODE mode)
-{
-	// 拡張子変更
-	string new_file_name = this->get_file_pass();
-	switch (mode)
-	{
-	case file_enc_c::CRYPT_MODE::ENCRYPT:
-		new_file_name += ".enc";
-		if (rename(this->get_file_pass().c_str(), new_file_name.c_str()))
-		{
-			ERROR("ファイル名の変更に失敗");
-			return;
-		}
-		break;
+void file_enc_c::extemsion_set(const file_enc_c::CRYPT_MODE mode) {
+    // 拡張子変更
+    string new_file_name = this->get_file_pass();
+    switch (mode) {
+        case file_enc_c::CRYPT_MODE::ENCRYPT:
+            new_file_name += ".enc";
+            if (rename(this->get_file_pass().c_str(), new_file_name.c_str())) {
+                ERROR("ファイル名の変更に失敗");
+                return;
+            }
+            break;
 
-	case file_enc_c::CRYPT_MODE::DECRYPT:
-		if (new_file_name.find(".enc") != string::npos)
-		{
-			new_file_name.erase(new_file_name.find(".enc"), 4);
-		}
-		if (rename(this->get_file_pass().c_str(), new_file_name.c_str()))
-		{
-			ERROR("ファイル名の変更に失敗");
-			return;
-		}
-		break;
+        case file_enc_c::CRYPT_MODE::DECRYPT:
+            if (new_file_name.find(".enc") != string::npos) {
+                new_file_name.erase(new_file_name.find(".enc"), 4);
+            }
+            if (rename(this->get_file_pass().c_str(), new_file_name.c_str())) {
+                ERROR("ファイル名の変更に失敗");
+                return;
+            }
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 }

--- a/src/file_ptr_c.cpp
+++ b/src/file_ptr_c.cpp
@@ -2,64 +2,50 @@
 
 using namespace std;
 
-file_ptr_c::file_ptr_c(const string filename, const string option)
-{
-	this->fp_ = fopen(filename.c_str(), option.c_str());
+file_ptr_c::file_ptr_c(const string filename, const string option) {
+    this->fp_ = fopen(filename.c_str(), option.c_str());
 }
 
-file_ptr_c::file_ptr_c()
-{
-	this->fp_ = NULL;
+file_ptr_c::file_ptr_c() { this->fp_ = NULL; }
+
+file_ptr_c::~file_ptr_c() {
+    if (this->fp_ == NULL) {
+        return;
+    }
+    fclose(this->fp_);
+    this->fp_ = NULL;
 }
 
-file_ptr_c::~file_ptr_c()
-{
-	if (this->fp_ == NULL)
-	{
-		return;
-	}
-	fclose(this->fp_);
-	this->fp_ = NULL;
+bool file_ptr_c::open(const string filepath, const string option) {
+    if (this->fp_ != NULL) {
+        fclose(this->fp_);
+        this->fp_ = NULL;
+    }
+    this->fp_ = fopen(filepath.c_str(), option.c_str());
+    if (this->fp_ == NULL) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    return true;
 }
 
-bool file_ptr_c::open(const string filepath, const string option)
-{
-	if (this->fp_ != NULL)
-	{
-		fclose(this->fp_);
-		this->fp_ = NULL;
-	}
-	this->fp_ = fopen(filepath.c_str(), option.c_str());
-	if (this->fp_ == NULL)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	return true;
+bool file_ptr_c::reopen(const string filepath, const string option) {
+    if (this->fp_ != NULL) {
+        fclose(this->fp_);
+        this->fp_ = NULL;
+    }
+    this->fp_ = fopen(filepath.c_str(), option.c_str());
+    if (this->fp_ == NULL) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    return true;
 }
 
-bool file_ptr_c::reopen(const string filepath, const string option)
-{
-	if (this->fp_ != NULL)
-	{
-		fclose(this->fp_);
-		this->fp_ = NULL;
-	}
-	this->fp_ = fopen(filepath.c_str(), option.c_str());
-	if (this->fp_ == NULL)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	return true;
-}
-
-void file_ptr_c::close()
-{
-	if (this->fp_ == NULL || this->fp_ == nullptr)
-	{
-		return;
-	}
-	fclose(this->fp_);
-	this->fp_ = NULL;
+void file_ptr_c::close() {
+    if (this->fp_ == NULL || this->fp_ == nullptr) {
+        return;
+    }
+    fclose(this->fp_);
+    this->fp_ = NULL;
 }

--- a/src/key_gen_c.cpp
+++ b/src/key_gen_c.cpp
@@ -2,238 +2,197 @@
 
 using namespace std;
 
-key_gen_c::key_gen_c()
-{
-	this->pass_.clear();
-	this->usbID_.clear();
-	this->usbSerial_.clear();
+key_gen_c::key_gen_c() {
+    this->pass_.clear();
+    this->usbID_.clear();
+    this->usbSerial_.clear();
 }
 
-key_gen_c::~key_gen_c()
-{
+key_gen_c::~key_gen_c() {}
+
+bool key_gen_c::set_pass(std::string const pass) {
+    if (pass.empty()) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    this->pass_ = pass;
+    return true;
 }
 
-bool key_gen_c::set_pass(std::string const pass)
-{
-	if (pass.empty())
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	this->pass_ = pass;
-	return true;
+string key_gen_c::get_pass() const {
+    if (this->pass_.empty()) {
+        return "";
+    }
+    return this->pass_;
 }
 
-string key_gen_c::get_pass() const
-{
-	if (this->pass_.empty())
-	{
-		return "";
-	}
-	return this->pass_;
+bool key_gen_c::canKeyGen() const {
+    if (this->pass_.empty() || this->get_usbSerial().empty()) {
+        return false;
+    }
+    return true;
 }
 
-bool key_gen_c::canKeyGen() const
-{
-	if (this->pass_.empty() || this->get_usbSerial().empty())
-	{
-		return false;
-	}
-	return true;
+string key_gen_c::get_usbSerial() const {
+    if (this->usbSerial_.empty()) {
+        PRINT_ERROR_LOG("USBのシリアル番号がセットされていません");
+        return "";
+    }
+    return this->usbSerial_;
 }
 
-string key_gen_c::get_usbSerial() const
-{
-	if (this->usbSerial_.empty())
-	{
-		PRINT_ERROR_LOG("USBのシリアル番号がセットされていません");
-		return "";
-	}
-	return this->usbSerial_;
+bool key_gen_c::new_key_gen() {
+    this->set_nonce();
+    return this->key_gen();
 }
 
-bool key_gen_c::new_key_gen()
-{
-	this->set_nonce();
-	return this->key_gen();
+bool key_gen_c::key_gen() {
+    if (this->canKeyGen() == false) {
+        PRINT_ERROR_LOG("鍵の生成条件を満たしていません");
+        return false;
+    }
+
+    dynamic_mem_c nonce;
+    nonce.d_new(NONCE_SIZE);
+    if (this->get_nonce(nonce) == false) {
+        PRINT_ERROR_LOG("nonceを取得できませんでした");
+    }
+
+    string buf;
+    buf = this->get_pass() + this->get_usbSerial();
+    dynamic_mem_c key;
+    key.d_new(NONCE_SIZE + buf.size());
+    for (size_t i = 0; i < key.size(); i++) {
+        if (i < buf.size()) {
+            key.mem_[i] = (u_char)buf[i];
+        } else {
+            key.mem_[i] = nonce.mem_[i];
+        }
+    }
+    SHA_c sha;
+
+    // cout << "buf: " << buf << "\n"
+    //  << "key: " << sha.str2hex(key) << endl;
+
+    this->key_.d_new(SHA256_DIGEST_LENGTH);
+    if (key.empty()) {
+        PRINT_ERROR_LOG("ハッシュ値に渡す変数が空です");
+        return false;
+    }
+    if (sha.sha2_cal(key, this->key_, SHA_c::SHA2_bit::SHA_256) == false) {
+        PRINT_ERROR_LOG("鍵を取得できませんでした");
+        this->key_.d_free();
+        return false;
+    }
+    return true;
 }
 
-bool key_gen_c::key_gen()
-{
-	if (this->canKeyGen() == false)
-	{
-		PRINT_ERROR_LOG("鍵の生成条件を満たしていません");
-		return false;
-	}
+bool key_gen_c::get_nonce(dynamic_mem_c &to) const {
+    if (to.size() != NONCE_SIZE) {
+        PRINT_ERROR_LOG("nonceを格納する大きさがありません");
+        return false;
+    }
 
-	dynamic_mem_c nonce;
-	nonce.d_new(NONCE_SIZE);
-	if (this->get_nonce(nonce) == false)
-	{
-		PRINT_ERROR_LOG("nonceを取得できませんでした");
-	}
-
-	string buf;
-	buf = this->get_pass() + this->get_usbSerial();
-	dynamic_mem_c key;
-	key.d_new(NONCE_SIZE + buf.size());
-	for (size_t i = 0; i < key.size(); i++)
-	{
-		if (i < buf.size())
-		{
-			key.mem_[i] = (u_char)buf[i];
-		}
-		else
-		{
-			key.mem_[i] = nonce.mem_[i];
-		}
-	}
-	SHA_c sha;
-
-	// cout << "buf: " << buf << "\n"
-	//  << "key: " << sha.str2hex(key) << endl;
-
-	this->key_.d_new(SHA256_DIGEST_LENGTH);
-	if (key.empty())
-	{
-		PRINT_ERROR_LOG("ハッシュ値に渡す変数が空です");
-		return false;
-	}
-	if (sha.sha2_cal(key, this->key_, SHA_c::SHA2_bit::SHA_256) == false)
-	{
-		PRINT_ERROR_LOG("鍵を取得できませんでした");
-		this->key_.d_free();
-		return false;
-	}
-	return true;
+    file_ptr_c fp;
+    if (fp.open(NONCE_FILE, "rb") == false) {
+        PRINT_ERROR_LOG("nonceファイルを読み取れません");
+        return false;
+    }
+    if (fread(to.mem_, 1, NONCE_SIZE, fp.fp_) != NONCE_SIZE) {
+        PRINT_ERROR_LOG("nonceのサイズが違います");
+        return false;
+    }
+    return true;
 }
 
-bool key_gen_c::get_nonce(dynamic_mem_c &to) const
-{
-	if (to.size() != NONCE_SIZE)
-	{
-		PRINT_ERROR_LOG("nonceを格納する大きさがありません");
-		return false;
-	}
-
-	file_ptr_c fp;
-	if (fp.open(NONCE_FILE, "rb") == false)
-	{
-		PRINT_ERROR_LOG("nonceファイルを読み取れません");
-		return false;
-	}
-	if (fread(to.mem_, 1, NONCE_SIZE, fp.fp_) != NONCE_SIZE)
-	{
-		PRINT_ERROR_LOG("nonceのサイズが違います");
-		return false;
-	}
-	return true;
+bool key_gen_c::set_nonce() const {
+    file_ptr_c fp;
+    if (fp.open(NONCE_FILE, "wb") == false) {
+        PRINT_ERROR_LOG("nonceファイルが開けません");
+        return false;
+    }
+    dynamic_mem_c rand;
+    rand.d_new(NONCE_SIZE);
+    RAND_bytes(rand.mem_, NONCE_SIZE);
+    fwrite(rand.mem_, 1, rand.size(), fp.fp_);
+    return true;
 }
 
-bool key_gen_c::set_nonce() const
-{
-	file_ptr_c fp;
-	if (fp.open(NONCE_FILE, "wb") == false)
-	{
-		PRINT_ERROR_LOG("nonceファイルが開けません");
-		return false;
-	}
-	dynamic_mem_c rand;
-	rand.d_new(NONCE_SIZE);
-	RAND_bytes(rand.mem_, NONCE_SIZE);
-	fwrite(rand.mem_, 1, rand.size(), fp.fp_);
-	return true;
+bool key_gen_c::set_UsbSerial() {
+    if (this->usbID_.empty()) {
+        PRINT_ERROR_LOG("USBIDが指定されていません");
+        return false;
+    }
+
+    FILE *fp;
+    string id = this->get_usbID();
+
+    string cmdline = "sudo lsusb -d ";
+    cmdline += id;
+    cmdline += " -v | grep iSerial | awk '{print $3}' ";
+    cout << "cmd: " << cmdline << endl;
+    if ((fp = popen(cmdline.c_str(), "r")) == NULL) {
+        PRINT_ERROR_LOG("can not exec commad");
+        return false;
+    }
+    char buf[256];
+
+    while (!feof(fp)) {
+        fgets(buf, sizeof(buf), fp);
+        printf("=> %s", buf);
+    }
+
+    (void)pclose(fp);
+    this->usbSerial_ = buf;
+    return true;
 }
 
-bool key_gen_c::set_UsbSerial()
-{
-	if (this->usbID_.empty())
-	{
-		PRINT_ERROR_LOG("USBIDが指定されていません");
-		return false;
-	}
+bool key_gen_c::set_usbID(string const id) {
+    if (id.empty()) {
+        PRINT_ERROR_LOG("idが空");
+        return false;
+    }
+    if (id.find(":") == string::npos) {
+        PRINT_ERROR_LOG("不正な引数");
+        return false;
+    }
 
-	FILE *fp;
-	string id = this->get_usbID();
+    string cmdline;
+    cmdline += "lsusb | grep ";
+    cmdline += id;
+    FILE *fp;
+    if ((fp = popen(cmdline.c_str(), "r")) == NULL) {
+        PRINT_ERROR_LOG("can not exec commad");
+        return false;
+    }
 
-	string cmdline = "sudo lsusb -d ";
-	cmdline += id;
-	cmdline += " -v | grep iSerial | awk '{print $3}' ";
-	cout << "cmd: " << cmdline << endl;
-	if ((fp = popen(cmdline.c_str(), "r")) == NULL)
-	{
-		PRINT_ERROR_LOG("can not exec commad");
-		return false;
-	}
-	char buf[256];
+    char buf[256] = {"0"};
+    string result;
+    while (!feof(fp)) {
+        fgets(buf, sizeof(buf), fp);
+        result += buf;
+    }
+    if (result.size() < 10) {
+        PRINT_ERROR_LOG("USBが検出できません");
+        return false;
+    }
 
-	while (!feof(fp))
-	{
-		fgets(buf, sizeof(buf), fp);
-		printf("=> %s", buf);
-	}
+    this->usbID_ = id;
 
-	(void)pclose(fp);
-	this->usbSerial_ = buf;
-	return true;
+    return true;
 }
 
-bool key_gen_c::set_usbID(string const id)
-{
-	if (id.empty())
-	{
-		PRINT_ERROR_LOG("idが空");
-		return false;
-	}
-	if (id.find(":") == string::npos)
-	{
-		PRINT_ERROR_LOG("不正な引数");
-		return false;
-	}
-
-	string cmdline;
-	cmdline += "lsusb | grep ";
-	cmdline += id;
-	FILE *fp;
-	if ((fp = popen(cmdline.c_str(), "r")) == NULL)
-	{
-		PRINT_ERROR_LOG("can not exec commad");
-		return false;
-	}
-
-	char buf[256] = {"0"};
-	string result;
-	while (!feof(fp))
-	{
-		fgets(buf, sizeof(buf), fp);
-		result += buf;
-	}
-	if (result.size() < 10)
-	{
-		PRINT_ERROR_LOG("USBが検出できません");
-		return false;
-	}
-
-	this->usbID_ = id;
-
-	return true;
+string key_gen_c::get_usbID() const {
+    if (this->usbID_.empty()) {
+        return "";
+    }
+    return this->usbID_;
 }
 
-string key_gen_c::get_usbID() const
-{
-	if (this->usbID_.empty())
-	{
-		return "";
-	}
-	return this->usbID_;
-}
+dynamic_mem_c key_gen_c::get_key() const {
+    if (this->key_.empty()) {
+        PRINT_ERROR_LOG("鍵がありません");
+    }
 
-dynamic_mem_c key_gen_c::get_key() const
-{
-	if (this->key_.empty())
-	{
-		PRINT_ERROR_LOG("鍵がありません");
-	}
-
-	return this->key_;
+    return this->key_;
 }

--- a/src/key_list_c.cpp
+++ b/src/key_list_c.cpp
@@ -2,298 +2,257 @@
 
 using namespace std;
 
-key_list_c::key_list_c()
-{
-	file_ptr_c fp(KEY_FILE_NAME, "a");
+key_list_c::key_list_c() { file_ptr_c fp(KEY_FILE_NAME, "a"); }
+
+key_list_c::~key_list_c() {}
+
+string key_list_c::get_file_name() const {
+    if (this->key_file_name_.empty()) {
+        ERROR("ファイル名が指定されていません");
+        return nullptr;
+    }
+    return this->key_file_name_;
 }
 
-key_list_c::~key_list_c()
-{
+bool key_list_c::pop_file(dynamic_mem_c const &hash, dynamic_mem_c &iv,
+                          dynamic_mem_c &key) {
+    if (hash.empty()) {
+        return false;
+    }
+
+    file_ptr_c fp(this->get_file_name().c_str(), "rb");
+    fseek(fp.fp_, 0, SEEK_SET);
+
+    bool isFindHash = false;
+    const uint line_size = HASH_SIZE + AES_SIZE * 2;
+    dynamic_mem_c buffer(line_size);
+    u_char temp[HASH_SIZE];
+    size_t read_size = 0;
+
+    // ハッシュ値を検索
+    while ((read_size = fread(buffer.mem_, 1, line_size, fp.fp_)) > 0) {
+        if (read_size != line_size) {
+            break;
+        }
+        memcpy(temp, buffer.mem_, HASH_SIZE);
+        if (memcmp(temp, hash.mem_, HASH_SIZE) == 0) {
+            isFindHash = true;
+            break;
+        }
+    }
+    fp.close();
+
+    if (isFindHash == false) {
+        return false;
+    }
+
+    // iv, keyをコピー
+    for (size_t i = 0; i < HASH_SIZE; i++) {
+        iv.mem_[i] = buffer.mem_[i + HASH_SIZE];
+        key.mem_[i] = buffer.mem_[i + HASH_SIZE + AES_SIZE];
+    }
+
+    this->plug(hash);
+
+    return true;
 }
 
-string key_list_c::get_file_name() const
-{
-	if (this->key_file_name_.empty())
-	{
-		ERROR("ファイル名が指定されていません");
-		return nullptr;
-	}
-	return this->key_file_name_;
+bool key_list_c::plug(const dynamic_mem_c &hash) {
+    // 読み取りファイル
+    file_ptr_c fp(this->get_file_name().c_str(), "rb");
+
+    // バッファ用ファイル
+    const string buffer_file_name = BUFFER_FILE_NAME;
+    file_ptr_c buffer_fp(buffer_file_name.c_str(), "wb");
+
+    const uint line_size = HASH_SIZE + AES_SIZE * 2;
+    dynamic_mem_c buffer(line_size), temp(HASH_SIZE);
+
+    // バッファへ該当ハッシュ値のファイルの除いて書き出し
+    size_t read_size = 0;
+    while ((read_size = fread(buffer.mem_, 1, line_size, fp.fp_)) > 0) {
+        if (read_size != line_size) {
+            break;
+        }
+        if (memcmp(buffer.mem_, hash.mem_, HASH_SIZE) == 0) {
+            continue;
+        }
+        fwrite(buffer.mem_, 1, line_size, buffer_fp.fp_);
+    }
+
+    // バッファを読み取り元ファイルへ書き出し
+    buffer_fp.reopen(buffer_file_name.c_str(), "rb");
+    fp.reopen(this->get_file_name().c_str(), "wb");
+    while ((read_size = fread(buffer.mem_, 1, line_size, buffer_fp.fp_))) {
+        fwrite(buffer.mem_, 1, read_size, fp.fp_);
+    }
+    // バッファ用ファイルを初期化
+    buffer_fp.reopen(buffer_file_name.c_str(), "wb");
+    return true;
 }
 
-bool key_list_c::pop_file(dynamic_mem_c const &hash, dynamic_mem_c &iv, dynamic_mem_c &key)
-{
-	if (hash.empty())
-	{
-		return false;
-	}
+bool key_list_c::add_file(dynamic_mem_c const &hash, dynamic_mem_c const &iv,
+                          dynamic_mem_c const &key) const {
+    // hashに値は入っているか？
+    if (hash.empty() == true || iv.empty() == true || key.empty() == true) {
+        return false;
+    }
 
-	file_ptr_c fp(this->get_file_name().c_str(), "rb");
-	fseek(fp.fp_, 0, SEEK_SET);
+    file_ptr_c fp;
+    fp.open(this->get_file_name().c_str(), "ab");
 
-	bool isFindHash = false;
-	const uint line_size = HASH_SIZE + AES_SIZE * 2;
-	dynamic_mem_c buffer(line_size);
-	u_char temp[HASH_SIZE];
-	size_t read_size = 0;
+    fwrite(hash.mem_, 1, hash.size(), fp.fp_);
+    fwrite(iv.mem_, 1, iv.size(), fp.fp_);
+    fwrite(key.mem_, 1, key.size(), fp.fp_);
 
-	// ハッシュ値を検索
-	while ((read_size = fread(buffer.mem_, 1, line_size, fp.fp_)) > 0)
-	{
-		if (read_size != line_size)
-		{
-			break;
-		}
-		memcpy(temp, buffer.mem_, HASH_SIZE);
-		if (memcmp(temp, hash.mem_, HASH_SIZE) == 0)
-		{
-			isFindHash = true;
-			break;
-		}
-	}
-	fp.close();
-
-	if (isFindHash == false)
-	{
-		return false;
-	}
-
-	// iv, keyをコピー
-	for (size_t i = 0; i < HASH_SIZE; i++)
-	{
-		iv.mem_[i] = buffer.mem_[i + HASH_SIZE];
-		key.mem_[i] = buffer.mem_[i + HASH_SIZE + AES_SIZE];
-	}
-
-	this->plug(hash);
-
-	return true;
+    return true;
 }
 
-bool key_list_c::plug(const dynamic_mem_c &hash)
-{
-	// 読み取りファイル
-	file_ptr_c fp(this->get_file_name().c_str(), "rb");
+bool key_list_c::encrypt(dynamic_mem_c const &key) const {
+    if (key.empty() || key.size() != AES_SIZE) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	// バッファ用ファイル
-	const string buffer_file_name = BUFFER_FILE_NAME;
-	file_ptr_c buffer_fp(buffer_file_name.c_str(), "wb");
+    file_ptr_c fp;
+    if (fp.open(this->get_file_name(), "rb") == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	const uint line_size = HASH_SIZE + AES_SIZE * 2;
-	dynamic_mem_c buffer(line_size), temp(HASH_SIZE);
+    aes_c aes;
+    dynamic_mem_c iv;
+    iv.d_new(AES_SIZE);
+    RAND_bytes(iv.mem_, iv.size());
+    aes.set_iv_key(iv, key);
+    file_enc_c file_enc;
+    file_enc.set_file_path(this->get_file_name());
 
-	// バッファへ該当ハッシュ値のファイルの除いて書き出し
-	size_t read_size = 0;
-	while ((read_size = fread(buffer.mem_, 1, line_size, fp.fp_)) > 0)
-	{
-		if (read_size != line_size)
-		{
-			break;
-		}
-		if (memcmp(buffer.mem_, hash.mem_, HASH_SIZE) == 0)
-		{
-			continue;
-		}
-		fwrite(buffer.mem_, 1, line_size, buffer_fp.fp_);
-	}
+    if (file_enc.crypt_process(aes, file_enc_c::CRYPT_MODE::ENCRYPT) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	// バッファを読み取り元ファイルへ書き出し
-	buffer_fp.reopen(buffer_file_name.c_str(), "rb");
-	fp.reopen(this->get_file_name().c_str(), "wb");
-	while ((read_size = fread(buffer.mem_, 1, line_size, buffer_fp.fp_)))
-	{
-		fwrite(buffer.mem_, 1, read_size, fp.fp_);
-	}
-	// バッファ用ファイルを初期化
-	buffer_fp.reopen(buffer_file_name.c_str(), "wb");
-	return true;
+    fp.reopen(this->get_file_name().c_str(), "ab");
+    fwrite(iv.mem_, 1, iv.size(), fp.fp_);
+    fp.close();
+
+    file_enc.extemsion_set(file_enc_c::CRYPT_MODE::ENCRYPT);
+
+    this->key_list_pkey_update(key);
+
+    return true;
 }
 
-bool key_list_c::add_file(dynamic_mem_c const &hash, dynamic_mem_c const &iv, dynamic_mem_c const &key) const
-{
-	// hashに値は入っているか？
-	if (hash.empty() == true || iv.empty() == true || key.empty() == true)
-	{
-		return false;
-	}
+bool key_list_c::decrypt(dynamic_mem_c const &key) const {
+    if (key.empty() || key.size() != AES_SIZE) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    if (this->key_check(key) == false) {
+        ERROR("鍵が違います");
+        sleep(1);
+        return false;
+    }
+    file_ptr_c fp;
+    if (fp.open(this->get_file_name() + ".enc", "rb") == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	file_ptr_c fp;
-	fp.open(this->get_file_name().c_str(), "ab");
+    dynamic_mem_c iv;
+    iv.d_new(AES_SIZE);
+    fseek(fp.fp_, -iv.size(), SEEK_END);
+    size_t read_size = fread(iv.mem_, 1, iv.size(), fp.fp_);
+    if (read_size != AES_SIZE) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	fwrite(hash.mem_, 1, hash.size(), fp.fp_);
-	fwrite(iv.mem_, 1, iv.size(), fp.fp_);
-	fwrite(key.mem_, 1, key.size(), fp.fp_);
+    // 末尾のivを削除
+    fseek(fp.fp_, 0, SEEK_SET);
+    file_ptr_c buff_fp;
+    dynamic_mem_c buff;
+    buff.d_new(AES_SIZE);
+    buff_fp.open(BUFFER_FILE_NAME, "wb");
+    while (fread(buff.mem_, 1, buff.size(), fp.fp_) > 0) {
+        if (memcmp(buff.mem_, iv.mem_, iv.size()) == 0) {
+            break;
+        }
+        fwrite(buff.mem_, 1, buff.size(), buff_fp.fp_);
+    }
+    fp.reopen(this->get_file_name() + ".enc", "wb");
+    buff_fp.reopen(BUFFER_FILE_NAME, "rb");
+    while (fread(buff.mem_, 1, buff.size(), buff_fp.fp_) > 0) {
+        fwrite(buff.mem_, 1, buff.size(), fp.fp_);
+    }
+    buff_fp.close();
+    fp.close();
 
-	return true;
+    // ファイル復号
+    aes_c aes;
+    aes.set_iv_key(iv, key);
+    file_enc_c file_enc;
+    file_enc.set_file_path(this->get_file_name() + ".enc");
+
+    if (file_enc.crypt_process(aes, file_enc_c::CRYPT_MODE::DECRYPT) == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+
+    file_enc.extemsion_set(file_enc_c::CRYPT_MODE::DECRYPT);
+    return true;
 }
 
-bool key_list_c::encrypt(dynamic_mem_c const &key) const
-{
-	if (key.empty() || key.size() != AES_SIZE)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+bool key_list_c::key_check(dynamic_mem_c const &key) const {
+    if (key.size() < AES_SIZE || key.empty()) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    file_ptr_c fp;
+    if (fp.open(KEY_HASH_FILE, "rb") == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	file_ptr_c fp;
-	if (fp.open(this->get_file_name(), "rb") == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+    dynamic_mem_c temp;
+    temp.d_new(AES_SIZE);
+    size_t read_size = fread(temp.mem_, 1, temp.size(), fp.fp_);
+    if (read_size != temp.size()) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	aes_c aes;
-	dynamic_mem_c iv;
-	iv.d_new(AES_SIZE);
-	RAND_bytes(iv.mem_, iv.size());
-	aes.set_iv_key(iv, key);
-	file_enc_c file_enc;
-	file_enc.set_file_path(this->get_file_name());
-
-	if (file_enc.crypt_process(aes, file_enc_c::CRYPT_MODE::ENCRYPT) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	fp.reopen(this->get_file_name().c_str(), "ab");
-	fwrite(iv.mem_, 1, iv.size(), fp.fp_);
-	fp.close();
-
-	file_enc.extemsion_set(file_enc_c::CRYPT_MODE::ENCRYPT);
-
-	this->key_list_pkey_update(key);
-
-	return true;
+    SHA_c sha;
+    dynamic_mem_c hash;
+    hash.d_new(AES_SIZE);
+    sha.sha2_cal(key, hash, SHA_c::SHA2_bit::SHA_256);
+    if (memcmp(hash.mem_, temp.mem_, hash.size()) == 0) {
+        return true;
+    }
+    return false;
 }
 
-bool key_list_c::decrypt(dynamic_mem_c const &key) const
-{
-	if (key.empty() || key.size() != AES_SIZE)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	if (this->key_check(key) == false)
-	{
-		ERROR("鍵が違います");
-		sleep(1);
-		return false;
-	}
-	file_ptr_c fp;
-	if (fp.open(this->get_file_name() + ".enc", "rb") == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+bool key_list_c::key_list_pkey_update(dynamic_mem_c const &key) const {
+    if (key.mem_ == nullptr || key.size() != AES_SIZE) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	dynamic_mem_c iv;
-	iv.d_new(AES_SIZE);
-	fseek(fp.fp_, -iv.size(), SEEK_END);
-	size_t read_size = fread(iv.mem_, 1, iv.size(), fp.fp_);
-	if (read_size != AES_SIZE)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
+    file_ptr_c fp;
+    if (fp.open(KEY_HASH_FILE, "wb") == false) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
 
-	// 末尾のivを削除
-	fseek(fp.fp_, 0, SEEK_SET);
-	file_ptr_c buff_fp;
-	dynamic_mem_c buff;
-	buff.d_new(AES_SIZE);
-	buff_fp.open(BUFFER_FILE_NAME, "wb");
-	while (fread(buff.mem_, 1, buff.size(), fp.fp_) > 0)
-	{
-		if (memcmp(buff.mem_, iv.mem_, iv.size()) == 0)
-		{
-			break;
-		}
-		fwrite(buff.mem_, 1, buff.size(), buff_fp.fp_);
-	}
-	fp.reopen(this->get_file_name() + ".enc", "wb");
-	buff_fp.reopen(BUFFER_FILE_NAME, "rb");
-	while (fread(buff.mem_, 1, buff.size(), buff_fp.fp_) > 0)
-	{
-		fwrite(buff.mem_, 1, buff.size(), fp.fp_);
-	}
-	buff_fp.close();
-	fp.close();
+    SHA_c sha;
+    dynamic_mem_c hash;
+    hash.d_new(HASH_SIZE);
 
-	// ファイル復号
-	aes_c aes;
-	aes.set_iv_key(iv, key);
-	file_enc_c file_enc;
-	file_enc.set_file_path(this->get_file_name() + ".enc");
-
-	if (file_enc.crypt_process(aes, file_enc_c::CRYPT_MODE::DECRYPT) == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	file_enc.extemsion_set(file_enc_c::CRYPT_MODE::DECRYPT);
-	return true;
-}
-
-bool key_list_c::key_check(dynamic_mem_c const &key) const
-{
-	if (key.size() < AES_SIZE || key.empty())
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	file_ptr_c fp;
-	if (fp.open(KEY_HASH_FILE, "rb") == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	dynamic_mem_c temp;
-	temp.d_new(AES_SIZE);
-	size_t read_size = fread(temp.mem_, 1, temp.size(), fp.fp_);
-	if (read_size != temp.size())
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	SHA_c sha;
-	dynamic_mem_c hash;
-	hash.d_new(AES_SIZE);
-	sha.sha2_cal(key, hash, SHA_c::SHA2_bit::SHA_256);
-	if (memcmp(hash.mem_, temp.mem_, hash.size()) == 0)
-	{
-		return true;
-	}
-	return false;
-}
-
-bool key_list_c::key_list_pkey_update(dynamic_mem_c const &key) const
-{
-	if (key.mem_ == nullptr || key.size() != AES_SIZE)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	file_ptr_c fp;
-	if (fp.open(KEY_HASH_FILE, "wb") == false)
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-
-	SHA_c sha;
-	dynamic_mem_c hash;
-	hash.d_new(HASH_SIZE);
-
-	sha.sha2_cal(key, hash, SHA_c::SHA2_bit::SHA_256);
-	if (fwrite(hash.mem_, 1, hash.size(), fp.fp_) != hash.size())
-	{
-		ERROR_NO_COMMENT;
-		return false;
-	}
-	return true;
+    sha.sha2_cal(key, hash, SHA_c::SHA2_bit::SHA_256);
+    if (fwrite(hash.mem_, 1, hash.size(), fp.fp_) != hash.size()) {
+        ERROR_NO_COMMENT;
+        return false;
+    }
+    return true;
 }

--- a/src/sha_c.cpp
+++ b/src/sha_c.cpp
@@ -1,156 +1,130 @@
 #include "../include/sha_c.hpp"
 
-SHA_c::SHA_c()
-{
-}
+SHA_c::SHA_c() {}
 
-SHA_c::~SHA_c()
-{
-}
+SHA_c::~SHA_c() {}
 
 using namespace std;
 
-string SHA_c::sha1_cal(const string &src) const
-{
-
+string SHA_c::sha1_cal(const string &src) const {
     SHA_CTX sha_ctx;
-    if (!(SHA1_Init(&sha_ctx)))
-    {
+    if (!(SHA1_Init(&sha_ctx))) {
         ERROR("SHA1_Init");
         return nullptr;
     }
-    if (!(SHA1_Update(&sha_ctx, (void *)src.c_str(), src.length())))
-    {
+    if (!(SHA1_Update(&sha_ctx, (void *)src.c_str(), src.length()))) {
         ERROR("SHA1_Update");
         return nullptr;
     }
 
     string result;
-    unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA_DIGEST_LENGTH + 1));
-    if (!(SHA1_Final(buf, &sha_ctx)))
-    {
+    unsigned char *buf = static_cast<unsigned char *>(
+        calloc(sizeof(unsigned char), SHA_DIGEST_LENGTH + 1));
+    if (!(SHA1_Final(buf, &sha_ctx))) {
         ERROR("SHA1_Final");
         return nullptr;
     }
 
-    for (int i = 0; i < SHA_DIGEST_LENGTH; i++)
-    {
+    for (int i = 0; i < SHA_DIGEST_LENGTH; i++) {
         result.push_back(buf[i]);
     }
     return result;
 }
 
-string SHA_c::sha2_cal(const string &src, const SHA_c::SHA2_bit bit) const
-{
+string SHA_c::sha2_cal(const string &src, const SHA_c::SHA2_bit bit) const {
     string result;
-    if (bit == SHA_c::SHA2_bit::SHA_224)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_224) {
         SHA256_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA224_DIGEST_LENGTH + 1));
-        if (!SHA224_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA224_DIGEST_LENGTH + 1));
+        if (!SHA224_Init(&ctx)) {
             ERROR("SHA224_Init");
             return nullptr;
         }
 
-        if (!SHA224_Update(&ctx, src.c_str(), src.length()))
-        {
+        if (!SHA224_Update(&ctx, src.c_str(), src.length())) {
             ERROR("SHA224_Update");
             return nullptr;
         }
-        if (!SHA224_Final(buf, &ctx))
-        {
+        if (!SHA224_Final(buf, &ctx)) {
             ERROR("SHA224_Final");
             return nullptr;
         }
 
-        for (int i = 0; i < SHA224_DIGEST_LENGTH; i++)
-        {
+        for (int i = 0; i < SHA224_DIGEST_LENGTH; i++) {
             result.push_back(buf[i]);
         }
         free(buf);
         buf = nullptr;
         return result;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_256)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_256) {
         SHA256_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA256_DIGEST_LENGTH + 1));
-        if (!SHA256_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA256_DIGEST_LENGTH + 1));
+        if (!SHA256_Init(&ctx)) {
             ERROR("SHA256_Init");
             return nullptr;
         }
-        if (!SHA256_Update(&ctx, src.c_str(), src.length()))
-        {
+        if (!SHA256_Update(&ctx, src.c_str(), src.length())) {
             ERROR("SHA256_Update");
             return nullptr;
         }
-        if (!SHA256_Final(buf, &ctx))
-        {
+        if (!SHA256_Final(buf, &ctx)) {
             ERROR("SHA256_Final");
             return nullptr;
         }
-        for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-        {
+        for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
             result.push_back(buf[i]);
         }
         free(buf);
         buf = nullptr;
         return result;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_384)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_384) {
         SHA512_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA384_DIGEST_LENGTH + 1));
-        if (!SHA384_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA384_DIGEST_LENGTH + 1));
+        if (!SHA384_Init(&ctx)) {
             ERROR("SHA384_Init");
             return nullptr;
         }
-        if (!SHA384_Update(&ctx, src.c_str(), src.length()))
-        {
+        if (!SHA384_Update(&ctx, src.c_str(), src.length())) {
             ERROR("SHA384_Update");
             return nullptr;
         }
-        if (!SHA384_Final(buf, &ctx))
-        {
+        if (!SHA384_Final(buf, &ctx)) {
             ERROR("SHA384_Final");
             return nullptr;
         }
-        for (int i = 0; i < SHA384_DIGEST_LENGTH; i++)
-        {
+        for (int i = 0; i < SHA384_DIGEST_LENGTH; i++) {
             result.push_back(buf[i]);
         }
         free(buf);
         buf = nullptr;
         return result;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_512)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_512) {
         SHA512_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA512_DIGEST_LENGTH + 1));
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA512_DIGEST_LENGTH + 1));
         SHA512_Init(&ctx);
         SHA512_Update(&ctx, src.c_str(), src.length());
         SHA512_Final(buf, &ctx);
-        if (!SHA512_Init(&ctx))
-        {
+        if (!SHA512_Init(&ctx)) {
             ERROR("SHA512_Init");
             return nullptr;
         }
-        if (!SHA512_Update(&ctx, src.c_str(), src.length()))
-        {
+        if (!SHA512_Update(&ctx, src.c_str(), src.length())) {
             ERROR("SHA512_Update");
             return nullptr;
         }
-        if (!SHA512_Final(buf, &ctx))
-        {
+        if (!SHA512_Final(buf, &ctx)) {
             ERROR("SHA512_Final");
             return nullptr;
         }
 
-        for (int i = 0; i < SHA512_DIGEST_LENGTH; i++)
-        {
+        for (int i = 0; i < SHA512_DIGEST_LENGTH; i++) {
             result.push_back(buf[i]);
         }
         free(buf);
@@ -161,26 +135,23 @@ string SHA_c::sha2_cal(const string &src, const SHA_c::SHA2_bit bit) const
     return nullptr;
 }
 
-bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit bit) const
-{
+bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out,
+                     const SHA2_bit bit) const {
     string result;
-    if (bit == SHA_c::SHA2_bit::SHA_224)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_224) {
         SHA256_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA224_DIGEST_LENGTH + 1));
-        if (!SHA224_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA224_DIGEST_LENGTH + 1));
+        if (!SHA224_Init(&ctx)) {
             ERROR("SHA224_Init");
             return false;
         }
 
-        if (!SHA224_Update(&ctx, in.mem_, in.size()))
-        {
+        if (!SHA224_Update(&ctx, in.mem_, in.size())) {
             ERROR("SHA224_Update");
             return false;
         }
-        if (!SHA224_Final(buf, &ctx))
-        {
+        if (!SHA224_Final(buf, &ctx)) {
             ERROR("SHA224_Final");
             return false;
         }
@@ -190,22 +161,19 @@ bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit
         buf = nullptr;
         return true;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_256)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_256) {
         SHA256_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA256_DIGEST_LENGTH + 1));
-        if (!SHA256_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA256_DIGEST_LENGTH + 1));
+        if (!SHA256_Init(&ctx)) {
             ERROR("SHA256_Init");
             return false;
         }
-        if (!SHA256_Update(&ctx, in.mem_, in.size()))
-        {
+        if (!SHA256_Update(&ctx, in.mem_, in.size())) {
             ERROR("SHA256_Update");
             return false;
         }
-        if (!SHA256_Final(buf, &ctx))
-        {
+        if (!SHA256_Final(buf, &ctx)) {
             ERROR("SHA256_Final");
             return false;
         }
@@ -214,22 +182,19 @@ bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit
         buf = nullptr;
         return true;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_384)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_384) {
         SHA512_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA384_DIGEST_LENGTH + 1));
-        if (!SHA384_Init(&ctx))
-        {
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA384_DIGEST_LENGTH + 1));
+        if (!SHA384_Init(&ctx)) {
             ERROR("SHA384_Init");
             return false;
         }
-        if (!SHA384_Update(&ctx, in.mem_, in.size()))
-        {
+        if (!SHA384_Update(&ctx, in.mem_, in.size())) {
             ERROR("SHA384_Update");
             return false;
         }
-        if (!SHA384_Final(buf, &ctx))
-        {
+        if (!SHA384_Final(buf, &ctx)) {
             ERROR("SHA384_Final");
             return false;
         }
@@ -238,25 +203,22 @@ bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit
         buf = nullptr;
         return true;
     }
-    if (bit == SHA_c::SHA2_bit::SHA_512)
-    {
+    if (bit == SHA_c::SHA2_bit::SHA_512) {
         SHA512_CTX ctx;
-        unsigned char *buf = static_cast<unsigned char *>(calloc(sizeof(unsigned char), SHA512_DIGEST_LENGTH + 1));
+        unsigned char *buf = static_cast<unsigned char *>(
+            calloc(sizeof(unsigned char), SHA512_DIGEST_LENGTH + 1));
         SHA512_Init(&ctx);
         SHA512_Update(&ctx, in.mem_, in.size());
         SHA512_Final(buf, &ctx);
-        if (!SHA512_Init(&ctx))
-        {
+        if (!SHA512_Init(&ctx)) {
             ERROR("SHA512_Init");
             return false;
         }
-        if (!SHA512_Update(&ctx, in.mem_, in.size()))
-        {
+        if (!SHA512_Update(&ctx, in.mem_, in.size())) {
             ERROR("SHA512_Update");
             return false;
         }
-        if (!SHA512_Final(buf, &ctx))
-        {
+        if (!SHA512_Final(buf, &ctx)) {
             ERROR("SHA512_Final");
             return false;
         }
@@ -270,24 +232,20 @@ bool SHA_c::sha2_cal(const dynamic_mem_c &in, dynamic_mem_c &out, const SHA2_bit
     return false;
 }
 
-string SHA_c::str2hex(const string &src) const
-{
+string SHA_c::str2hex(const string &src) const {
     stringstream buf;
     char p[10];
-    for (uint i = 0; i < src.size(); i++)
-    {
+    for (uint i = 0; i < src.size(); i++) {
         sprintf(p, "%02x", (unsigned char)src[i]);
         buf << p;
     }
     return buf.str();
 }
 
-string SHA_c::str2hex(const dynamic_mem_c &src) const
-{
+string SHA_c::str2hex(const dynamic_mem_c &src) const {
     stringstream buf;
     char p[10];
-    for (uint i = 0; i < src.size(); i++)
-    {
+    for (uint i = 0; i < src.size(); i++) {
         sprintf(p, "%02x", src.mem_[i]);
         buf << p;
     }

--- a/test/include/test.hpp
+++ b/test/include/test.hpp
@@ -1,47 +1,46 @@
 #ifndef ___TEST_HPP
 #define ___TEST_HPP
 
-#include "string"
-#include "fstream"
-#include "iostream"
-#include "cstdio"
 #include <stdio.h>
 #include <stdlib.h>
-#include <vector>
+
 #include <algorithm>
+#include <vector>
+
+#include "cstdio"
+#include "fstream"
+#include "iostream"
+#include "string"
 #define BUF 256
 
+#include "../../include/device_c.hpp"
+#include "../../include/dynamic_mem_c.hpp"
+#include "../../include/file_enc.hpp"
+#include "../../include/key_gen.hpp"
+#include "../../include/sha_c.hpp"
 #include "gtest/gtest.h"
 #include "openssl/rand.h"
 
-#include "../../include/file_enc.hpp"
-#include "../../include/dynamic_mem_c.hpp"
-#include "../../include/sha_c.hpp"
-#include "../../include/key_gen.hpp"
-#include "../../include/device_c.hpp"
-
 #define ERROR_TEST        \
-	TestLog_c testLogIns; \
-	testLogIns.errorTest()
+    TestLog_c testLogIns; \
+    testLogIns.errorTest()
 
 #define NORMAL_TEST       \
-	TestLog_c testLogIns; \
-	testLogIns.correctTest()
+    TestLog_c testLogIns; \
+    testLogIns.correctTest()
 
-#define TEST_END \
-	testLogIns.~TestLog_c()
+#define TEST_END testLogIns.~TestLog_c()
 
-class TestLog_c
-{
-private:
-	/* data */
+class TestLog_c {
+   private:
+    /* data */
 
-public:
-	TestLog_c();
-	TestLog_c(const std::string comment);
-	void errorTest();
-	void correctTest();
-	~TestLog_c();
+   public:
+    TestLog_c();
+    TestLog_c(const std::string comment);
+    void errorTest();
+    void correctTest();
+    ~TestLog_c();
 };
 
 #endif

--- a/test/src/deviceTest.cpp
+++ b/test/src/deviceTest.cpp
@@ -2,33 +2,30 @@
 
 using namespace std;
 
-TEST(deviceTest, usbList)
-{
-	device_c usb;
-	vector<string> usb_list;
-	usb_list = usb.get_usbList();
-	ASSERT_FALSE(usb_list.empty());
-	cout << "usblist" << endl;
-	for (string usb : usb_list)
-	{
-		cout << usb << endl;
-	}
+TEST(deviceTest, usbList) {
+    device_c usb;
+    vector<string> usb_list;
+    usb_list = usb.get_usbList();
+    ASSERT_FALSE(usb_list.empty());
+    cout << "usblist" << endl;
+    for (string usb : usb_list) {
+        cout << usb << endl;
+    }
 }
 
-TEST(deviceTest, setUsbID)
-{
-	device_c usb;
-	ERROR_TEST;
-	ASSERT_FALSE(usb.set_usbID("hoge"));
-	ASSERT_FALSE(usb.set_usbID(""));
-	ASSERT_FALSE(usb.set_usbID("1d6b:000"));
-	ASSERT_FALSE(usb.set_usbID("1d6b:0005"));
-	TEST_END;
+TEST(deviceTest, setUsbID) {
+    device_c usb;
+    ERROR_TEST;
+    ASSERT_FALSE(usb.set_usbID("hoge"));
+    ASSERT_FALSE(usb.set_usbID(""));
+    ASSERT_FALSE(usb.set_usbID("1d6b:000"));
+    ASSERT_FALSE(usb.set_usbID("1d6b:0005"));
+    TEST_END;
 
-	ASSERT_TRUE(usb.set_usbID("1d6b:0002"));
-	string temp = usb.get_usbID();
-	ASSERT_STREQ("1d6b:0002", temp.c_str());
-	temp.clear();
-	temp = usb.get_usbSerial();
-	ASSERT_STREQ("0000:00:0b.0", temp.c_str());
+    ASSERT_TRUE(usb.set_usbID("1d6b:0002"));
+    string temp = usb.get_usbID();
+    ASSERT_STREQ("1d6b:0002", temp.c_str());
+    temp.clear();
+    temp = usb.get_usbSerial();
+    ASSERT_STREQ("0000:00:0b.0", temp.c_str());
 }

--- a/test/src/dynamicMemTest.cpp
+++ b/test/src/dynamicMemTest.cpp
@@ -1,46 +1,36 @@
 #include "../include/test.hpp"
 
-TEST(DMem, copyConst)
-{
+TEST(DMem, copyConst) {
     dynamic_mem_c from;
     from.d_new(100);
-    try
-    {
+    try {
         dynamic_mem_c to(from);
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
         std::cerr << e.what() << '\n';
         ERROR_NO_COMMENT;
         FAIL();
     }
 }
 
-TEST(DMem, equal)
-{
+TEST(DMem, equal) {
     dynamic_mem_c to, from;
     from.d_new(2);
     from.mem_[0] = 1;
-    if (from.empty())
-    {
+    if (from.empty()) {
         FAIL();
     }
     to = from;
-    if (from.empty())
-    {
+    if (from.empty()) {
         FAIL();
     }
-    try
-    {
+    try {
         to.d_free();
         to.d_new(2);
         from.d_free();
         from.d_new(2);
         from.mem_[0] = 1;
         to = from;
-    }
-    catch (const std::exception &e)
-    {
+    } catch (const std::exception &e) {
         std::cerr << e.what() << '\n';
         FAIL();
     }
@@ -48,8 +38,7 @@ TEST(DMem, equal)
     EXPECT_FALSE(to.empty());
 }
 
-TEST(DMem, empty)
-{
+TEST(DMem, empty) {
     dynamic_mem_c test;
     ASSERT_TRUE(test.empty());
     test.d_new(2);

--- a/test/src/keyGenTest.cpp
+++ b/test/src/keyGenTest.cpp
@@ -2,140 +2,123 @@
 
 using namespace std;
 
-TEST(keyGenMethodTest, setUsbId)
-{
-	key_gen_c key;
-	ASSERT_TRUE(key.set_usbID("1d6b:0002"));
-	ASSERT_FALSE(key.set_usbID(""));
-	ASSERT_FALSE(key.set_usbID("hoge"));
-	ASSERT_FALSE(key.set_usbID("1d6b"));
-	ASSERT_FALSE(key.set_usbID("0002"));
-	ASSERT_FALSE(key.set_usbID("1d6:0002"));
+TEST(keyGenMethodTest, setUsbId) {
+    key_gen_c key;
+    ASSERT_TRUE(key.set_usbID("1d6b:0002"));
+    ASSERT_FALSE(key.set_usbID(""));
+    ASSERT_FALSE(key.set_usbID("hoge"));
+    ASSERT_FALSE(key.set_usbID("1d6b"));
+    ASSERT_FALSE(key.set_usbID("0002"));
+    ASSERT_FALSE(key.set_usbID("1d6:0002"));
 }
 
-TEST(keyGenMethodTest, setPass)
-{
-	key_gen_c key;
-	ASSERT_TRUE(key.set_pass("hoge"));
-	ASSERT_FALSE(key.set_pass(""));
+TEST(keyGenMethodTest, setPass) {
+    key_gen_c key;
+    ASSERT_TRUE(key.set_pass("hoge"));
+    ASSERT_FALSE(key.set_pass(""));
 }
 
-TEST(keyGenMethodTest, canKeyGen)
-{
-	key_gen_c key;
-	ASSERT_FALSE(key.canKeyGen());
-	ASSERT_TRUE(key.set_pass("hoge"));
-	ASSERT_FALSE(key.canKeyGen());
-	ASSERT_TRUE(key.set_usbID("1d6b:0002"));
-	ASSERT_TRUE(key.set_UsbSerial());
-	ASSERT_TRUE(key.canKeyGen());
+TEST(keyGenMethodTest, canKeyGen) {
+    key_gen_c key;
+    ASSERT_FALSE(key.canKeyGen());
+    ASSERT_TRUE(key.set_pass("hoge"));
+    ASSERT_FALSE(key.canKeyGen());
+    ASSERT_TRUE(key.set_usbID("1d6b:0002"));
+    ASSERT_TRUE(key.set_UsbSerial());
+    ASSERT_TRUE(key.canKeyGen());
 }
 
-TEST(errorLogTest, printError)
-{
-	key_gen_c key;
-	PRINT_ERROR_LOG("test");
+TEST(errorLogTest, printError) {
+    key_gen_c key;
+    PRINT_ERROR_LOG("test");
 }
 
-TEST(keyGenMethodTest, setUsbSerial)
-{
-	key_gen_c key;
-	ASSERT_FALSE(key.set_UsbSerial());
-	ASSERT_TRUE(key.set_usbID("1d6b:0002"));
-	ASSERT_TRUE(key.set_UsbSerial());
+TEST(keyGenMethodTest, setUsbSerial) {
+    key_gen_c key;
+    ASSERT_FALSE(key.set_UsbSerial());
+    ASSERT_TRUE(key.set_usbID("1d6b:0002"));
+    ASSERT_TRUE(key.set_UsbSerial());
 }
 
-TEST(keyGenMethodTest, nonce)
-{
-	key_gen_c key;
-	dynamic_mem_c buf;
-	ASSERT_TRUE(key.set_nonce());
-	ASSERT_FALSE(key.get_nonce(buf));
+TEST(keyGenMethodTest, nonce) {
+    key_gen_c key;
+    dynamic_mem_c buf;
+    ASSERT_TRUE(key.set_nonce());
+    ASSERT_FALSE(key.get_nonce(buf));
 
-	buf.d_new(1);
-	ASSERT_FALSE(key.get_nonce(buf));
-	buf.d_new(NONCE_SIZE - 1);
-	ASSERT_FALSE(key.get_nonce(buf));
+    buf.d_new(1);
+    ASSERT_FALSE(key.get_nonce(buf));
+    buf.d_new(NONCE_SIZE - 1);
+    ASSERT_FALSE(key.get_nonce(buf));
 
-	buf.d_new(NONCE_SIZE);
-	ASSERT_TRUE(key.get_nonce(buf));
-	buf.d_new(NONCE_SIZE * 2);
-	ASSERT_FALSE(key.get_nonce(buf));
+    buf.d_new(NONCE_SIZE);
+    ASSERT_TRUE(key.get_nonce(buf));
+    buf.d_new(NONCE_SIZE * 2);
+    ASSERT_FALSE(key.get_nonce(buf));
 }
 
-TEST(keyGenMethodTest, keyGen)
-{
-	TestLog_c test("鍵生成テスト");
-	key_gen_c key;
-	EXPECT_FALSE(key.new_key_gen());
+TEST(keyGenMethodTest, keyGen) {
+    TestLog_c test("鍵生成テスト");
+    key_gen_c key;
+    EXPECT_FALSE(key.new_key_gen());
 
-	ASSERT_TRUE(key.set_pass("hoge"));
-	EXPECT_FALSE(key.new_key_gen());
+    ASSERT_TRUE(key.set_pass("hoge"));
+    EXPECT_FALSE(key.new_key_gen());
 
-	ASSERT_TRUE(key.set_usbID("1d6b:0002"));
-	EXPECT_FALSE(key.new_key_gen());
+    ASSERT_TRUE(key.set_usbID("1d6b:0002"));
+    EXPECT_FALSE(key.new_key_gen());
 
-	ASSERT_TRUE(key.set_UsbSerial());
-	ASSERT_TRUE(key.new_key_gen());
+    ASSERT_TRUE(key.set_UsbSerial());
+    ASSERT_TRUE(key.new_key_gen());
 }
 
 #if 1
-TEST(keyGenMethodTest, getKey)
-{
-	TestLog_c test("鍵入手テスト");
-	key_gen_c key;
-	ASSERT_TRUE(key.set_pass("hoge"));
-	ASSERT_TRUE(key.set_usbID("1d6b:0002"));
-	ASSERT_TRUE(key.set_UsbSerial());
-	ASSERT_TRUE(key.canKeyGen());
-	ASSERT_TRUE(key.new_key_gen());
+TEST(keyGenMethodTest, getKey) {
+    TestLog_c test("鍵入手テスト");
+    key_gen_c key;
+    ASSERT_TRUE(key.set_pass("hoge"));
+    ASSERT_TRUE(key.set_usbID("1d6b:0002"));
+    ASSERT_TRUE(key.set_UsbSerial());
+    ASSERT_TRUE(key.canKeyGen());
+    ASSERT_TRUE(key.new_key_gen());
 
-	dynamic_mem_c key_1;
-	dynamic_mem_c key_2;
-	try
-	{
-		key_1 = key.get_key();
-	}
-	catch (const std::exception &e)
-	{
-		std::cerr << e.what() << '\n';
-		FAIL();
-	}
-	if (key_1.empty())
-	{
-		FAIL();
-	}
+    dynamic_mem_c key_1;
+    dynamic_mem_c key_2;
+    try {
+        key_1 = key.get_key();
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << '\n';
+        FAIL();
+    }
+    if (key_1.empty()) {
+        FAIL();
+    }
 
-	key_gen_c key_check;
-	key_check.set_pass("hoge");
-	key_check.set_usbID("1d6b:0002");
-	key_check.set_UsbSerial();
-	key_check.canKeyGen();
-	ASSERT_TRUE(key_check.key_gen());
-	try
-	{
-		key_2 = key_check.get_key();
-	}
-	catch (const std::exception &e)
-	{
-		std::cerr << e.what() << '\n';
-		FAIL();
-	}
+    key_gen_c key_check;
+    key_check.set_pass("hoge");
+    key_check.set_usbID("1d6b:0002");
+    key_check.set_UsbSerial();
+    key_check.canKeyGen();
+    ASSERT_TRUE(key_check.key_gen());
+    try {
+        key_2 = key_check.get_key();
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << '\n';
+        FAIL();
+    }
 
-	EXPECT_FALSE(key_1.empty());
-	EXPECT_FALSE(key_2.empty());
-	for (size_t i = 0; i < key_1.size(); i++)
-	{
-		if (key_1.mem_[i] != key_2.mem_[i])
-		{
-			FAIL();
-		}
-	}
+    EXPECT_FALSE(key_1.empty());
+    EXPECT_FALSE(key_2.empty());
+    for (size_t i = 0; i < key_1.size(); i++) {
+        if (key_1.mem_[i] != key_2.mem_[i]) {
+            FAIL();
+        }
+    }
 
-	cout << "key1: ";
-	SHA_c sha;
-	cout << sha.str2hex(key_1);
-	cout << "\n"
-		 << "key2: " << sha.str2hex(key_2) << endl;
+    cout << "key1: ";
+    SHA_c sha;
+    cout << sha.str2hex(key_1);
+    cout << "\n"
+         << "key2: " << sha.str2hex(key_2) << endl;
 }
 #endif

--- a/test/src/key_list_test.cpp
+++ b/test/src/key_list_test.cpp
@@ -2,17 +2,14 @@
 
 using namespace std;
 
-TEST(KeyListCryptTest, EncryptTest)
-{
-
+TEST(KeyListCryptTest, EncryptTest) {
     key_list_c keyList;
     dynamic_mem_c key;
     string pass("hoge");
     SHA_c sha;
     string key_st = sha.sha2_cal(pass, SHA_c::SHA2_bit::SHA_256);
     key.d_new(SHA256_DIGEST_LENGTH);
-    for (size_t i = 0; i < key.size(); i++)
-    {
+    for (size_t i = 0; i < key.size(); i++) {
         key.mem_[i] = (unsigned char)key_st[i];
     }
     cout << sha.str2hex(key_st) << endl;
@@ -22,8 +19,7 @@ TEST(KeyListCryptTest, EncryptTest)
     ASSERT_TRUE(keyList.decrypt(key));
 }
 
-TEST(KeyListCryptError, DISABLED_KeySize)
-{
+TEST(KeyListCryptError, DISABLED_KeySize) {
     key_list_c keyList;
     dynamic_mem_c key;
     // 鍵のサイズが違う
@@ -33,8 +29,7 @@ TEST(KeyListCryptError, DISABLED_KeySize)
     ASSERT_FALSE(keyList.decrypt(key));
 }
 
-TEST(KeyListCryptError, DISABLED_NullKey)
-{
+TEST(KeyListCryptError, DISABLED_NullKey) {
     key_list_c keyList;
     dynamic_mem_c key;
     key.d_new(AES_SIZE);
@@ -42,8 +37,7 @@ TEST(KeyListCryptError, DISABLED_NullKey)
     ASSERT_FALSE(keyList.decrypt(key));
 }
 
-TEST(KeyListCryptError, DISABLED_DiffKey)
-{
+TEST(KeyListCryptError, DISABLED_DiffKey) {
     key_list_c keyList;
     dynamic_mem_c key;
     key.d_new(AES_SIZE);

--- a/test/src/test.cpp
+++ b/test/src/test.cpp
@@ -2,85 +2,81 @@
 
 using namespace std;
 
-void create_rand_hash(dynamic_mem_c &hash)
-{
-	dynamic_mem_c temp(hash.size());
-	RAND_bytes(temp.mem_, hash.size());
+void create_rand_hash(dynamic_mem_c &hash) {
+    dynamic_mem_c temp(hash.size());
+    RAND_bytes(temp.mem_, hash.size());
 
-	SHA_c sha;
-	sha.sha2_cal(temp, hash, SHA_c::SHA2_bit::SHA_256);
+    SHA_c sha;
+    sha.sha2_cal(temp, hash, SHA_c::SHA2_bit::SHA_256);
 }
 
-TEST(KeyListTest, TrueProcess)
-{
-	int crypt_size = 256 / 8;
-	dynamic_mem_c hash(crypt_size), iv(crypt_size), key(crypt_size), temp(crypt_size);
-	SHA_c sha;
-	temp.mem_[0] = 1;
-	sha.sha2_cal(temp, hash, SHA_c::SHA2_bit::SHA_256);
+TEST(KeyListTest, TrueProcess) {
+    int crypt_size = 256 / 8;
+    dynamic_mem_c hash(crypt_size), iv(crypt_size), key(crypt_size),
+        temp(crypt_size);
+    SHA_c sha;
+    temp.mem_[0] = 1;
+    sha.sha2_cal(temp, hash, SHA_c::SHA2_bit::SHA_256);
 
-	file_ptr_c fp;
-	key_list_c testKey;
-	fp.open(testKey.get_file_name(), "wb");
-	fp.~file_ptr_c();
+    file_ptr_c fp;
+    key_list_c testKey;
+    fp.open(testKey.get_file_name(), "wb");
+    fp.~file_ptr_c();
 
-	for (auto i = 0; i < 3; i++)
-	{
-		create_rand_hash(hash);
-		create_rand_hash(iv);
-		create_rand_hash(key);
-		ASSERT_TRUE(testKey.add_file(hash, iv, key));
-	}
-	ASSERT_TRUE(testKey.add_file(hash, iv, key));
+    for (auto i = 0; i < 3; i++) {
+        create_rand_hash(hash);
+        create_rand_hash(iv);
+        create_rand_hash(key);
+        ASSERT_TRUE(testKey.add_file(hash, iv, key));
+    }
+    ASSERT_TRUE(testKey.add_file(hash, iv, key));
 
-	ASSERT_TRUE(testKey.pop_file(hash, iv, key));
-	string out_hash, out_iv, out_key;
-	for (size_t i = 0; i < hash.size(); i++)
-	{
-		out_hash.push_back(hash.mem_[i]);
-		out_iv.push_back(iv.mem_[i]);
-		out_key.push_back(key.mem_[i]);
-	}
-	cout << "hash: " << sha.str2hex(out_hash) << endl;
-	cout << "iv: " << sha.str2hex(out_iv) << endl;
-	cout << "key: " << sha.str2hex(out_key) << endl;
+    ASSERT_TRUE(testKey.pop_file(hash, iv, key));
+    string out_hash, out_iv, out_key;
+    for (size_t i = 0; i < hash.size(); i++) {
+        out_hash.push_back(hash.mem_[i]);
+        out_iv.push_back(iv.mem_[i]);
+        out_key.push_back(key.mem_[i]);
+    }
+    cout << "hash: " << sha.str2hex(out_hash) << endl;
+    cout << "iv: " << sha.str2hex(out_iv) << endl;
+    cout << "key: " << sha.str2hex(out_key) << endl;
 }
 
-TEST(KeyListTest, FalseProcess)
-{
-	int crypt_size = 256 / 8;
-	dynamic_mem_c hash(crypt_size), iv(crypt_size), key(crypt_size), temp(crypt_size);
-	SHA_c sha;
-	key_list_c testKey;
-	ASSERT_FALSE(testKey.add_file(hash, iv, key));
-	ASSERT_FALSE(testKey.pop_file(hash, iv, key));
+TEST(KeyListTest, FalseProcess) {
+    int crypt_size = 256 / 8;
+    dynamic_mem_c hash(crypt_size), iv(crypt_size), key(crypt_size),
+        temp(crypt_size);
+    SHA_c sha;
+    key_list_c testKey;
+    ASSERT_FALSE(testKey.add_file(hash, iv, key));
+    ASSERT_FALSE(testKey.pop_file(hash, iv, key));
 
-	create_rand_hash(temp);
-	ASSERT_FALSE(testKey.pop_file(temp, iv, key));
+    create_rand_hash(temp);
+    ASSERT_FALSE(testKey.pop_file(temp, iv, key));
 }
 
-TEST(FileEncTest, Normal)
-{
-	const string test_filepath("/home/taka/github/2021_sec/test/data.jpg");
-	file_enc_c file_enc;
-	ASSERT_TRUE(file_enc.set_file_path(test_filepath));
-	ASSERT_TRUE(file_enc.is_file_exit());
-	ASSERT_TRUE(file_enc.file_enc());
+TEST(FileEncTest, Normal) {
+    const string test_filepath("/home/taka/github/2021_sec/test/data.jpg");
+    file_enc_c file_enc;
+    ASSERT_TRUE(file_enc.set_file_path(test_filepath));
+    ASSERT_TRUE(file_enc.is_file_exit());
+    ASSERT_TRUE(file_enc.file_enc());
 
-	ASSERT_TRUE(file_enc.set_file_path(test_filepath + ".enc"));
-	ASSERT_TRUE(file_enc.file_dec());
+    ASSERT_TRUE(file_enc.set_file_path(test_filepath + ".enc"));
+    ASSERT_TRUE(file_enc.file_dec());
 }
 
-TEST(FileEncTest, ErrorProcess)
-{
-	const string error_filepath("/home/taka/github/2021_sec/test/hogehoge.huga");
-	file_enc_c file_enc;
-	ASSERT_FALSE(file_enc.set_file_path(error_filepath));
-	ASSERT_FALSE(file_enc.is_file_exit());
-	ASSERT_FALSE(file_enc.file_enc());
+TEST(FileEncTest, ErrorProcess) {
+    const string error_filepath(
+        "/home/taka/github/2021_sec/test/hogehoge.huga");
+    file_enc_c file_enc;
+    ASSERT_FALSE(file_enc.set_file_path(error_filepath));
+    ASSERT_FALSE(file_enc.is_file_exit());
+    ASSERT_FALSE(file_enc.file_enc());
 
-	ASSERT_FALSE(file_enc.set_file_path(error_filepath + ".enc"));
-	ASSERT_FALSE(file_enc.file_dec());
+    ASSERT_FALSE(file_enc.set_file_path(error_filepath + ".enc"));
+    ASSERT_FALSE(file_enc.file_dec());
 }
 
 #if 0

--- a/test/src/test_log.cpp
+++ b/test/src/test_log.cpp
@@ -2,35 +2,27 @@
 
 using namespace std;
 
-TestLog_c::TestLog_c()
-{
+TestLog_c::TestLog_c() {}
+
+TestLog_c::TestLog_c(const string comment) {
+    string text = "===";
+    text += comment;
+    text += "===";
+    PRINT_ERROR_LOG(text.c_str());
 }
 
-TestLog_c::TestLog_c(const string comment)
-{
-	string text = "===";
-	text += comment;
-	text += "===";
-	PRINT_ERROR_LOG(text.c_str());
+TestLog_c::~TestLog_c() { PRINT_ERROR_LOG("===TEST END==="); }
+
+void TestLog_c::correctTest() {
+    string text = "===";
+    text += "Correct Test";
+    text += "===";
+    PRINT_ERROR_LOG(text.c_str());
 }
 
-TestLog_c::~TestLog_c()
-{
-	PRINT_ERROR_LOG("===TEST END===");
-}
-
-void TestLog_c::correctTest()
-{
-	string text = "===";
-	text += "Correct Test";
-	text += "===";
-	PRINT_ERROR_LOG(text.c_str());
-}
-
-void TestLog_c::errorTest()
-{
-	string text = "===";
-	text += "Error Test";
-	text += "===";
-	PRINT_ERROR_LOG(text.c_str());
+void TestLog_c::errorTest() {
+    string text = "===";
+    text += "Error Test";
+    text += "===";
+    PRINT_ERROR_LOG(text.c_str());
 }


### PR DESCRIPTION
## 概要
#1 で clang-format 用の CI を導入したが、format 対象はPRに含まれる差分のコードのみである。そのため、既存コードの format を別途行う必要があり、この PR で format 後のコードを追加する。

なお、ローカルでビルド成功は確認済である。